### PR TITLE
Port PUT user

### DIFF
--- a/__mocks__/github.js
+++ b/__mocks__/github.js
@@ -1,0 +1,25 @@
+export default class {
+  constructor() {
+    let credentials = {};
+
+    this.authenticate = (creds) => {
+      credentials = creds;
+    };
+
+    this.authorization = {};
+    this.authorization.getOrCreateAuthorizationForApp = (opts) => {
+      switch(credentials.username) {
+        case 'error':
+          throw new Error('Error occured creating token.');
+        case 'first-time':
+          return { token: 'first-token' };
+        case 'logged-in':
+          // GitHub will not return a token if one already exists
+          // for security reasons.
+          return { token: '' };
+      }
+    };
+    this.authorization.create = (opts) => ({ token: 'fresh-token' });
+    this.authorization.delete = (opts) => ({});
+  }
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "aws-sdk": "^2.7.10",
     "babel-loader": "^6.2.10",
-    "babel-polyfill": "^6.22.0",
     "babel-preset-env": "^1.1.8",
     "eslint": "^3.14.1",
     "eslint-config-airbnb-base": "^11.0.1",
@@ -14,7 +13,8 @@
     "jest": "^18.1.0",
     "json-loader": "^0.5.4",
     "nsp": "^2.6.2",
-    "serverless-webpack": "^1.0.0-rc.4"
+    "serverless-webpack": "^1.0.0-rc.4",
+    "webpack-node-externals": "^1.5.4"
   },
   "scripts": {
     "lint": "node_modules/.bin/eslint ./src",
@@ -39,6 +39,8 @@
   "homepage": "https://github.com/craftship/yith#readme",
   "dependencies": {
     "babel-runtime": "^6.22.0",
+    "babel-polyfill": "^6.22.0",
+    "github": "^8.1.1",
     "node-fetch": "^1.6.3"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -58,6 +58,13 @@ functions:
           path: 'registry/-/package/{name}/dist-tags/{tag}'
           method: delete
 
+  userPut:
+    handler: userPut.default
+    events:
+      - http:
+          path: 'registry/-/user/{id}'
+          method: put
+
 resources:
   Resources:
     PackageStorage:
@@ -65,3 +72,6 @@ resources:
       Properties:
         AccessControl: Private
         BucketName: ${self:provider.environment.bucket}
+
+custom:
+  webpackIncludeModules: true

--- a/src/user/__tests__/put.js
+++ b/src/user/__tests__/put.js
@@ -1,0 +1,87 @@
+jest.mock('github');
+
+const handler = require('../put');
+
+describe('PUT /registry/-/user/{id}', () => {
+  let callback;
+  let subject;
+
+  beforeEach(() => {
+    callback = jest.fn();
+    subject = handler.default;
+    process.env = {
+      githubUrl: 'https://example.com/',
+      githubClientId: 'client',
+      githubSecret: 'secret',
+    };
+  });
+
+  describe('user signs in for first time', () => {
+    let event;
+
+    beforeEach(() => {
+      event = {
+        body: '{"name":"first-time","password":"bar"}',
+      };
+    });
+
+    it('should return token with correct response', async () => {
+      await subject(event, jest.fn(), callback);
+
+      expect(callback)
+      .toHaveBeenCalledWith(null, {
+        statusCode: 201,
+        body: JSON.stringify({
+          ok: true,
+          token: 'first-token',
+        }),
+      });
+    });
+  });
+
+  describe('user already logged in', () => {
+    let event;
+
+    beforeEach(() => {
+      event = {
+        body: '{"name":"logged-in","password":"bar"}',
+      };
+    });
+
+    it('should return fresh token with correct response', async () => {
+      await subject(event, jest.fn(), callback);
+
+      expect(callback)
+      .toHaveBeenCalledWith(null, {
+        statusCode: 201,
+        body: JSON.stringify({
+          ok: true,
+          token: 'fresh-token',
+        }),
+      });
+    });
+  });
+
+  describe('error occurs', () => {
+    let event;
+
+    beforeEach(() => {
+      event = {
+        body: '{"name":"error","password":"bar"}',
+      };
+    });
+
+    it('should return correct error response', async () => {
+      await subject(event, jest.fn(), callback);
+
+      expect(callback)
+      .toHaveBeenCalledWith(null, {
+        statusCode: 500,
+        body: JSON.stringify({
+          ok: false,
+          error: 'Error occured creating token.',
+        }),
+      });
+    });
+  });
+});

--- a/src/user/put.js
+++ b/src/user/put.js
@@ -1,0 +1,75 @@
+import url from 'url';
+import GitHub from 'github';
+
+export default async ({ body }, context, callback) => {
+  const {
+    name,
+    password,
+  } = JSON.parse(body);
+
+  const scopes = ['user:email'];
+  const nameParts = name.split('.');
+  const username = nameParts[0];
+  const otp = nameParts.length > 1 ? nameParts[nameParts.length - 1] : '';
+
+  const parsedUrl = url.parse(process.env.githubUrl);
+  const github = new GitHub({
+    host: parsedUrl.host,
+    protocol: 'https',
+    pathPrefix: parsedUrl.path,
+  });
+
+  github.authenticate({
+    type: 'basic',
+    username,
+    password,
+  });
+
+  let auth = {};
+  try {
+    auth = await github.authorization.getOrCreateAuthorizationForApp({
+      scopes,
+      client_id: process.env.githubClientId,
+      client_secret: process.env.githubSecret,
+      note: 'yith private npm registry',
+      headers: {
+        'X-GitHub-OTP': otp,
+      },
+    });
+
+    if (!auth.token.length) {
+      await github.authorization.delete({
+        id: auth.id,
+        headers: {
+          'X-GitHub-OTP': otp,
+        },
+      });
+
+      auth = await github.authorization.create({
+        scopes,
+        client_id: process.env.githubClientId,
+        client_secret: process.env.githubSecret,
+        note: 'yith private npm registry',
+        headers: {
+          'X-GitHub-OTP': otp,
+        },
+      });
+    }
+
+    return callback(null, {
+      statusCode: 201,
+      body: JSON.stringify({
+        ok: true,
+        token: auth.token,
+      }),
+    });
+  } catch (error) {
+    return callback(null, {
+      statusCode: 500,
+      body: JSON.stringify({
+        ok: false,
+        error: error.message,
+      }),
+    });
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,15 @@
+var nodeExternals = require('webpack-node-externals');
 var path = require('path');
 
 module.exports = {
   target: 'node',
+  externals: [nodeExternals()],
   entry: {
     get: ['./boostrap', './src/get.js'],
     distTagsGet: ['./boostrap', './src/dist-tags/get.js'],
     distTagsPut: ['./boostrap', './src/dist-tags/put.js'],
     distTagsDelete: ['./boostrap', './src/dist-tags/delete.js'],
+    userPut: ['./boostrap', './src/user/put.js'],
   },
   output: {
     libraryTarget: 'commonjs',


### PR DESCRIPTION
* Ported user put that allows `npm login`
* Add quick mock for github to allow test coverage

GitHub should potentially be abstracted out to `adapters` to make it easier and much better to test.  As this was a porting exercise, covered a decent amount and will re-visit.