### PR TITLE
Bug Fix Dist Tags Version

### DIFF
--- a/src/dist-tags/__tests__/put.js
+++ b/src/dist-tags/__tests__/put.js
@@ -26,7 +26,7 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
           name: 'private-foo',
           tag: 'newtag',
         },
-        body: '2.0.0',
+        body: '"2.0.0"',
       };
     });
 

--- a/src/dist-tags/put.js
+++ b/src/dist-tags/put.js
@@ -8,7 +8,7 @@ export default async ({ body, pathParameters }, context, callback) => {
   try {
     const pkgBuffer = await storage.get(`${name}/index.json`);
     const json = JSON.parse(pkgBuffer.toString());
-    json['dist-tags'][pathParameters.tag] = body;
+    json['dist-tags'][pathParameters.tag] = body.replace(/"/g, '');
 
     await storage.put(
       `${name}/index.json`,


### PR DESCRIPTION
* NPM CLI sends a body of version with quotation marks :trumpet:, this change removes them accordingly.