### PR TITLE
Port over Github Authorizer

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,6 +11,7 @@ provider:
   runtime: nodejs4.3
   stage: dev
   environment:
+    admins: ${env:YITH_ADMINS}
     registry: ${env:YITH_REGISTRY}
     githubUrl: ${env:YITH_GITHUB_URL}
     githubClientId:  ${env:YITH_GITHUB_CLIENT_ID}
@@ -32,18 +33,23 @@ provider:
         - "arn:aws:apigateway:*"
 
 functions:
+  authorizerGithub:
+    handler: authorizerGithub.default
+
   put:
     handler: put.default
     events:
       - http:
           path: 'registry/{name}'
           method: put
+          authorizer: authorizerGithub
   get:
     handler: get.default
     events:
       - http:
           path: 'registry/{name}'
           method: get
+          authorizer: authorizerGithub
 
   distTagsGet:
     handler: distTagsGet.default
@@ -51,18 +57,21 @@ functions:
       - http:
           path: 'registry/-/package/{name}/dist-tags'
           method: get
+          authorizer: authorizerGithub
   distTagsPut:
     handler: distTagsPut.default
     events:
       - http:
           path: 'registry/-/package/{name}/dist-tags/{tag}'
           method: put
+          authorizer: authorizerGithub
   distTagsDelete:
     handler: distTagsDelete.default
     events:
       - http:
           path: 'registry/-/package/{name}/dist-tags/{tag}'
           method: delete
+          authorizer: authorizerGithub
 
   userPut:
     handler: userPut.default
@@ -77,6 +86,7 @@ functions:
       - http:
           path: 'registry/{name}/-/{tar}'
           method: get
+          authorizer: authorizerGithub
 
 resources:
   Resources:

--- a/src/authorizers/github.js
+++ b/src/authorizers/github.js
@@ -1,0 +1,98 @@
+import url from 'url';
+import GitHub from 'github';
+
+const generatePolicy = ({
+  effect,
+  methodArn,
+  token,
+  isAdmin,
+}) => {
+  const methodParts = methodArn.split(':');
+  const region = methodParts[3];
+  const accountArn = methodParts[4];
+  const apiId = methodParts[5].split('/')[0];
+  const stage = methodParts[5].split('/')[1];
+
+  const authResponse = {};
+  authResponse.principalId = token;
+
+  const policyDocument = {};
+  policyDocument.Version = '2012-10-17';
+  policyDocument.Statement = [];
+
+  const statementOne = {};
+  statementOne.Action = 'execute-api:Invoke';
+  statementOne.Effect = effect;
+  statementOne.Resource = `arn:aws:execute-api:${region}:${accountArn}:${apiId}/${stage}/GET/registry*`;
+  policyDocument.Statement[0] = statementOne;
+
+  const statementTwo = {};
+  statementTwo.Action = 'execute-api:Invoke';
+  statementTwo.Effect = isAdmin ? 'Allow' : 'Deny';
+  statementTwo.Resource = `arn:aws:execute-api:${region}:${accountArn}:${apiId}/${stage}/PUT/registry*`;
+  policyDocument.Statement[1] = statementTwo;
+
+  const statementThree = {};
+  statementThree.Action = 'execute-api:Invoke';
+  statementThree.Effect = isAdmin ? 'Allow' : 'Deny';
+  statementThree.Resource = `arn:aws:execute-api:${region}:${accountArn}:${apiId}/${stage}/DELETE/registry*`;
+  policyDocument.Statement[2] = statementThree;
+
+  authResponse.policyDocument = policyDocument;
+
+  return authResponse;
+};
+
+export default async ({ methodArn, authorizationToken }, context, callback) => {
+  const tokenParts = authorizationToken.split('Bearer ');
+
+  if (tokenParts.length <= 1) {
+    return callback(null, generatePolicy({
+      token: authorizationToken,
+      effect: 'Deny',
+      methodArn,
+      isAdmin: false,
+    }));
+  }
+
+  const token = tokenParts[1];
+
+  const parsedUrl = url.parse(process.env.githubUrl);
+  const github = new GitHub({
+    host: parsedUrl.host,
+    protocol: 'https',
+    pathPrefix: parsedUrl.path,
+  });
+
+  github.authenticate({
+    type: 'basic',
+    username: process.env.githubClientId,
+    password: process.env.githubSecret,
+  });
+
+  try {
+    const { user } = await github.authorization.check({
+      client_id: process.env.githubClientId,
+      access_token: token,
+    });
+
+    let isAdmin = false;
+    if (process.env.admins) {
+      isAdmin = process.env.admins.split(',').indexOf(user.login) > -1;
+    }
+
+    return callback(null, generatePolicy({
+      effect: 'Allow',
+      methodArn,
+      token,
+      isAdmin,
+    }));
+  } catch (error) {
+    return callback(null, generatePolicy({
+      token: authorizationToken,
+      effect: 'Deny',
+      methodArn,
+      isAdmin: false,
+    }));
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   target: 'node',
   externals: [nodeExternals()],
   entry: {
+    authorizerGithub: ['./boostrap', './src/authorizers/github.js'],
     put: ['./boostrap', './src/put.js'],
     get: ['./boostrap', './src/get.js'],
     distTagsGet: ['./boostrap', './src/dist-tags/get.js'],


### PR DESCRIPTION
* Now uses env variable `,` delimited to add in administrators
* Policy firmed up to only allow `GET` for the specific aws account, api and stage, for admins `PUT` / `DELETE` operations are allowed.

This means all config is done via environment variables, thought process here is that hopefully setup should end up being as simple as:

1. Set up ENV variables:
```
export YITH_ADMINS="username1,username2"
export YITH_REGISTRY="https://registry.npmjs.org/"
export YITH_BUCKET="npm-registry-bucket"
export YITH_GITHUB_URL="https://api.github.com/"
export YITH_GITHUB_CLIENT_ID="client_id"
export YITH_GITHUB_SECRET="secret"
```
2. `sls install https://github.com/craftship/yith-next`
3. `sls deploy --stage prod`
