### PR TITLE
Binary Setup for GET Tar / Plugin

### DIFF
--- a/.serverless_plugins/content-handling/index.js
+++ b/.serverless_plugins/content-handling/index.js
@@ -1,0 +1,63 @@
+class ContentHandling {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    this.provider = this.serverless.getProvider('aws');
+
+    this.hooks = {
+      'after:deploy:deploy': this.afterDeploy.bind(this),
+    };
+  }
+
+  afterDeploy() {
+    const apiName = this.provider.naming.getApiGatewayName();
+    const funcs = this.serverless.service.functions;
+    const apigateway = new this.provider.sdk.APIGateway({
+      region: this.options.region,
+    });
+    const integrationResponse = {
+      statusCode: '200',
+    };
+
+    apigateway.getRestApis().promise()
+    .then((apis) => {
+      integrationResponse.restApiId = apis.items.find(api => api.name === apiName).id;
+    }).then(() => {
+      Object.keys(funcs).forEach((fKey) => {
+        funcs[fKey].events.forEach((e) => {
+          if (e.http && e.http.contentHandling) {
+            integrationResponse.httpMethod = e.http.method.toUpperCase();
+            integrationResponse.contentHandling = e.http.contentHandling;
+
+            apigateway.getResources({
+              restApiId: integrationResponse.restApiId,
+            }).promise()
+            .then((resources) => {
+              integrationResponse.resourceId = resources.items.find(r => r.path === `/${e.http.path}`).id;
+              return apigateway.putIntegrationResponse(integrationResponse).promise();
+            })
+            .then((result) => {
+              if (result.statusCode === '200') {
+                return apigateway.createDeployment({
+                  stageName: this.options.stage,
+                  restApiId: integrationResponse.restApiId,
+                }).promise();
+              }
+
+              throw new Error(`Could not set ${integrationResponse.contentHandling} for ${e.http.path}, method ${integrationResponse.httpMethod}`);
+            })
+            .then(() => {
+              this.serverless.cli.log('Setup for AWS API Gateway content handling complete.');
+            })
+            .catch((err) => {
+              this.serverless.cli.log(err.message);
+            });
+          }
+        });
+      });
+    });
+  }
+}
+
+module.exports = ContentHandling;

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,6 +2,7 @@ frameworkVersion: '=1.5.1'
 
 plugins:
   - serverless-webpack
+  - content-handling
 
 service: yith
 
@@ -84,9 +85,18 @@ functions:
     handler: tarGet.default
     events:
       - http:
+          integration: lambda
+          authorizer: authorizerGithub
           path: 'registry/{name}/-/{tar}'
           method: get
-          authorizer: authorizerGithub
+          contentHandling: CONVERT_TO_BINARY
+          request:
+            template:
+              application/json: >
+                {
+                  "name": "$input.params('name')",
+                  "tar": "$input.params('tar')"
+                }
 
 resources:
   Resources:

--- a/src/tar/get.js
+++ b/src/tar/get.js
@@ -1,51 +1,27 @@
 import npm from '../adapters/npm';
 import S3 from '../adapters/s3';
 
-export default async ({ pathParameters }, context, callback) => {
+export default async (event, context, callback) => {
   const { registry, bucket, region } = process.env;
-  const name = `${decodeURIComponent(pathParameters.name)}`;
-  const tarName = `${decodeURIComponent(pathParameters.tar)}`;
+  const name = `${decodeURIComponent(event.name)}`;
+  const tarName = `${decodeURIComponent(event.tar)}`;
   const storage = new S3({ region, bucket });
 
   try {
     const fileName = tarName.replace(`${name}-`, '');
     const pkgBuffer = await storage.get(`${name}/${fileName}`);
 
-    return callback(null, {
-      statusCode: 200,
-      headers: {
-        'Content-Type': 'application/x-tar',
-      },
-      body: pkgBuffer.toString('base64'),
-      isBase64Encoded: true,
-    });
+    return callback(null, pkgBuffer.toString('base64'));
   } catch (storageError) {
     if (storageError.code === 'NoSuchKey') {
       try {
-        const npmPkgBuffer = await npm.tar(registry, `${pathParameters.name}/-/${pathParameters.tar}`);
-        return callback(null, {
-          statusCode: 200,
-          headers: {
-            'Content-Type': 'application/x-tar',
-          },
-          body: npmPkgBuffer.toString('base64'),
-          isBase64Encoded: true,
-        });
+        const npmPkgBuffer = await npm.tar(registry, `${event.name}/-/${event.tar}`);
+        return callback(null, npmPkgBuffer.toString('base64'));
       } catch (npmError) {
-        return callback(null, {
-          statusCode: npmError.status,
-          body: JSON.stringify({
-            error: npmError.message,
-          }),
-        });
+        return callback(npmError);
       }
     }
 
-    return callback(null, {
-      statusCode: 500,
-      body: JSON.stringify({
-        error: storageError.message,
-      }),
-    });
+    return callback(storageError);
   }
 };


### PR DESCRIPTION
* This was an absolute pain to get setup for many reasons, now have a plugin local to the repo that for now sets up `contentHandling` nicely.  Can just pop it in the `serverless.yml` file and after deployment it will be setup.

Could only seem to get this to work without using Lambda Proxy integration for this specific function.