### PR TITLE
Fix Scoped NPM Passthrough URLS

### DIFF
--- a/src/get.js
+++ b/src/get.js
@@ -16,7 +16,7 @@ export default async ({ pathParameters }, context, callback) => {
   } catch (storageError) {
     if (storageError.code === 'NoSuchKey') {
       try {
-        const data = await npm.package(registry, name);
+        const data = await npm.package(registry, pathParameters.name);
         return callback(null, {
           statusCode: 200,
           body: JSON.stringify(data),


### PR DESCRIPTION
* Need to use encoded parameter when passing request through to npm for scoped packages specifically.