### PR TITLE
Fix Local Webpack Serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jest": "^18.1.0",
     "json-loader": "^0.5.4",
     "nsp": "^2.6.2",
-    "serverless-webpack": "^1.0.0-rc.4",
+    "serverless-webpack": "git+ssh://git@github.com/craftship/serverless-webpack.git",
     "webpack-node-externals": "^1.5.4"
   },
   "scripts": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -41,14 +41,14 @@ functions:
     handler: put.default
     events:
       - http:
-          path: '/registry/{name}'
+          path: 'registry/{name}'
           method: put
           authorizer: authorizerGithub
   get:
     handler: get.default
     events:
       - http:
-          path: '/registry/{name}'
+          path: 'registry/{name}'
           method: get
           authorizer: authorizerGithub
 
@@ -56,21 +56,21 @@ functions:
     handler: distTagsGet.default
     events:
       - http:
-          path: '/registry/-/package/{name}/dist-tags'
+          path: 'registry/-/package/{name}/dist-tags'
           method: get
           authorizer: authorizerGithub
   distTagsPut:
     handler: distTagsPut.default
     events:
       - http:
-          path: '/registry/-/package/{name}/dist-tags/{tag}'
+          path: 'registry/-/package/{name}/dist-tags/{tag}'
           method: put
           authorizer: authorizerGithub
   distTagsDelete:
     handler: distTagsDelete.default
     events:
       - http:
-          path: '/registry/-/package/{name}/dist-tags/{tag}'
+          path: 'registry/-/package/{name}/dist-tags/{tag}'
           method: delete
           authorizer: authorizerGithub
 
@@ -78,7 +78,7 @@ functions:
     handler: userPut.default
     events:
       - http:
-          path: '/registry/-/user/{id}'
+          path: 'registry/-/user/{id}'
           method: put
 
   tarGet:
@@ -87,7 +87,7 @@ functions:
       - http:
           integration: lambda
           authorizer: authorizerGithub
-          path: '/registry/{name}/-/{tar}'
+          path: 'registry/{name}/-/{tar}'
           method: get
           contentHandling: CONVERT_TO_BINARY
           request:


### PR DESCRIPTION
* Could not run `serverless webpack serve --stage dev` as body parsing did not match the behaviour of AWS Lambda Proxy Integration.
* This uses version from craftship that has a potential fix but needs discussion with the `serverless-webpack` maintainers.

Ultimately you can now create an S3 bucket in AWS (will automate or mock somehow soon), as long as you have AWS credentials that can access get and put objects then you get a completely local registry that you can run `npm set registry http://localhost:8000/{stage}/registry`.

Debug and test locally!

:dancing_men: 