### PR TITLE
Integration Tests Strategy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/integration-test
+++ b/bin/integration-test
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+NODE_TAG=$1
+
+docker build \
+--rm=false \
+--build-arg sls_version=1.6.1 \
+-t yith-node-$NODE_TAG \
+-q \
+-f ./integration/Dockerfile-$NODE_TAG .
+
+docker run \
+-e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+-e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+-e YITH_REGION=${YITH_REGION} \
+-e YITH_ADMINS=${YITH_ADMINS} \
+-e YITH_REGISTRY=${YITH_REGISTRY} \
+-e YITH_BUCKET=${YITH_BUCKET} \
+-e YITH_GITHUB_URL=${YITH_GITHUB_URL} \
+-e YITH_GITHUB_CLIENT_ID=${YITH_GITHUB_CLIENT_ID} \
+-e YITH_GITHUB_SECRET=${YITH_GITHUB_SECRET} \
+-e NPM_LOGIN_TOKEN=${NPM_LOGIN_TOKEN} \
+-e CIRCLE_SHA1=${CIRCLE_SHA1} \
+-e CIRCLE_NODE_INDEX=${CIRCLE_NODE_INDEX} \
+-it \
+--rm=false \
+--name yith-node-$NODE_TAG yith-node-$NODE_TAG

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  services:
+    - docker
   node:
     version: 7.4.0
 
@@ -6,5 +8,8 @@ test:
   pre:
     - npm run nsp
     - npm run lint
-  post:
+  override:
+    - npm run test
     - npm run coveralls
+    - case $CIRCLE_NODE_INDEX in 0) ./bin/integration-test latest ;; 1) ./bin/integration-test lts ;; esac:
+        parallel: true

--- a/integration/Dockerfile-latest
+++ b/integration/Dockerfile-latest
@@ -1,0 +1,13 @@
+FROM node:7.5.0
+
+ARG sls_version
+
+ADD . /yith
+
+WORKDIR /yith
+
+RUN npm install --silent
+
+RUN npm install serverless@$sls_version -g --silent
+
+CMD ./integration/bin/test

--- a/integration/Dockerfile-lts
+++ b/integration/Dockerfile-lts
@@ -1,0 +1,13 @@
+FROM node:6.9.5
+
+ARG sls_version
+
+ADD . /yith
+
+WORKDIR /yith
+
+RUN npm install --silent
+
+RUN npm install serverless@$sls_version -g --silent
+
+CMD ./integration/bin/test

--- a/integration/bin/deploy
+++ b/integration/bin/deploy
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const path = require('path');
+
+const spawn = require('child_process').spawn;
+
+let stage = 'integration';
+
+if (process.env.CIRCLE_SHA1) {
+  stage = `${process.env.CIRCLE_SHA1.substring(0, 8)}${process.env.CIRCLE_NODE_INDEX}`;
+}
+
+console.log(`Deploying yith ${stage}...`);
+
+const slsDeploy = spawn('sls', ['deploy', '--stage', stage]);
+
+let registryUrl;
+
+slsDeploy.stdout.on('data', (data) => {
+  if (!registryUrl) {
+    const registryRegex = new RegExp('https://.+?(?={name})');
+    const urls = registryRegex.exec(data.toString());
+
+    if (urls) {
+      registryUrl = urls[0];
+      const urlParts = registryUrl.split('/');
+      const loginUrl = `//${urlParts[2]}/${urlParts[3]}/${urlParts[4]}/:_authToken=${process.env.NPM_LOGIN_TOKEN}`;
+      fs.writeFileSync(path.resolve(process.env.PWD, '.npmrc'), `registry=${registryUrl}\r\n${loginUrl}\r\n`);
+    }
+  }
+});
+
+slsDeploy.on('close', (code) => {
+  if (code === 0) {
+    console.log(`Finished deployment for yith ${stage} : code ${code}`);
+  } else {
+    throw new Error(code);
+  }
+});

--- a/integration/bin/remove
+++ b/integration/bin/remove
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+STAGE='integration'
+[ -n "${CIRCLE_SHA1}" ] && STAGE="${CIRCLE_SHA1:0:8}${CIRCLE_NODE_INDEX}"
+
+sls remove --stage $STAGE
+rm .npmrc

--- a/integration/bin/test
+++ b/integration/bin/test
@@ -1,0 +1,3 @@
+./integration/bin/deploy
+$(npm bin)/mocha ./integration -t 15000 # Timeout set due to function cold starts
+./integration/bin/remove

--- a/integration/helpers.js
+++ b/integration/helpers.js
@@ -1,0 +1,56 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import AWS from 'aws-sdk';
+import { execFile as exec } from 'child_process';
+
+const S3 = new AWS.S3();
+
+export default {
+  package: {
+    publish: () =>
+      new Promise((resolve) => {
+        exec('npm', ['publish', './integration/test-package'], () => {
+          resolve();
+        });
+      }),
+    delete: async () => {
+      const fixture = 'test-package';
+      let stage = 'integration';
+
+      if (process.env.CIRCLE_SHA1) {
+        stage = `${process.env.CIRCLE_SHA1.substring(0, 8)}${process.env.CIRCLE_NODE_INDEX || ''}`;
+      }
+
+      const bucket = `${process.env.YITH_BUCKET}-${stage}`;
+
+      let items;
+      try {
+        items = await S3.listObjectsV2({
+          Bucket: bucket,
+          Prefix: fixture,
+        }).promise();
+      } catch (err) {
+        throw new Error(`Could not list S3 objects for ${bucket}`);
+      }
+
+      items.Contents.forEach(async (item) => {
+        try {
+          await S3.deleteObject({
+            Bucket: bucket,
+            Key: item.Key,
+          }).promise();
+        } catch (err) {
+          throw new Error(`Could not delete S3 object ${item.Key}`);
+        }
+      });
+
+      try {
+        await S3.deleteObject({
+          Bucket: bucket,
+          Key: fixture,
+        }).promise();
+      } catch (err) {
+        throw new Error(`Could not delee test package from ${bucket}`);
+      }
+    },
+  },
+};

--- a/integration/npm.test.js
+++ b/integration/npm.test.js
@@ -1,0 +1,71 @@
+import { execFile as exec } from 'child_process';
+import helpers from './helpers';
+
+describe('npm', () => {
+  context('get registry', () => {
+    it('should use private registry', (done) => {
+      exec('npm', ['get', 'registry'], { env: process.env }, (_, stdout) => {
+        assert(!stdout.includes('registry.npmjs.org'));
+        done();
+      });
+    });
+  });
+
+  context('publish <pkg>', () => {
+    afterEach(async () => helpers.package.delete());
+
+    it('should not allow a re-publish', (done) => {
+      exec('npm', ['publish', './integration/test-package'], () => {
+        exec('npm', ['publish', './integration/test-package'], (_, stdout) => {
+          assert(!stdout.includes('test-package@1.0.0'));
+          done();
+        });
+      });
+    });
+
+    it('should publish a new package correctly', (done) => {
+      exec('npm', ['publish', './integration/test-package'], (_, stdout) => {
+        assert(stdout.includes('test-package@1.0.0'));
+        done();
+      });
+    });
+  });
+
+  context('dist-tags', () => {
+    beforeEach(async () => helpers.package.publish());
+
+    it('should list tags correctly', (done) => {
+      exec('npm', ['dist-tags', 'add', 'test-package@1.0.0', 'alpha'], (_, stdout) => {
+        assert(stdout.includes('alpha'));
+        done();
+      });
+    });
+
+    it('should add tag correctly', (done) => {
+      exec('npm', ['dist-tags', 'add', 'test-package@1.0.0', 'alpha'], (_, stdout) => {
+        assert(stdout.includes('+alpha: test-package@1.0.0'));
+        done();
+      });
+    });
+
+    it('should rm tag correctly', (done) => {
+      exec('npm', ['dist-tags', 'add', 'test-package@1.0.0', 'alpha'], () => {
+        exec('npm', ['dist-tags', 'rm', 'test-package', 'alpha'], (_, stdout) => {
+          assert(stdout.includes('-alpha: test-package@1.0.0'));
+          done();
+        });
+      });
+    });
+
+    afterEach(async () => helpers.package.delete());
+  });
+
+  context('info', () => {
+    it('should return package json ok', (done) => {
+      exec('npm', ['info', 'serverless'], { env: process.env }, (error, stdout) => {
+        assert(stdout.includes('name: \'serverless\''));
+        done();
+      });
+    });
+  });
+});

--- a/integration/test-package/index.js
+++ b/integration/test-package/index.js
@@ -1,0 +1,3 @@
+const pkg = require('./package.json');
+
+console.log(`${pkg.name} ${pkg.version}`);

--- a/integration/test-package/package.json
+++ b/integration/test-package/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-package",
+  "version": "1.0.0",
+  "description": "Test package for integration tests",
+  "main": "index.js",
+  "author": "Craftship Ltd <hello@craftship.io>",
+  "license": "MIT"
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mocha": "^3.2.0",
     "nsp": "^2.6.2",
     "nyc": "^10.1.2",
-    "serverless-webpack": "git+ssh://git@github.com/craftship/serverless-webpack.git",
+    "serverless-webpack": "https://github.com/craftship/serverless-webpack.git",
     "sinon": "^1.17.7",
     "webpack-node-externals": "^1.5.4"
   },

--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-frameworkVersion: '=1.5.1'
+frameworkVersion: '=1.6.1'
 
 plugins:
   - environment-variables


### PR DESCRIPTION
## What did you implement:

A quick spike on creating integration tests so that:

a) Can test deployment works end to end
b) Test the npm CLI / version works with the private npm registry
c) Allows scope for adding integration tests for other package managers like yarn to test compatibility

## How did you implement it:

Created Dockerfiles to support testing against LTS and latest version of node (ultimately testing the included npm version).  Then created a new folder `integration` that holds tests.

Updated `circle.yml` to then build and run containers that deploys and runs integration tests accordingly.

## How can we verify it:

Check CircleCI for this branch and see if build passes.

## Todos:

- [x] Write tests
- [ ] Write documentation, whole readme coming which includes this.
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
