### PR TITLE
Project and bucket stage is now read from CLI

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -18,7 +18,7 @@ provider:
     githubUrl: ${env:YITH_GITHUB_URL}
     githubClientId:  ${env:YITH_GITHUB_CLIENT_ID}
     githubSecret:  ${env:YITH_GITHUB_SECRET}
-    bucket: ${env:YITH_BUCKET}-${opt:stage}
+    bucket: ${env:YITH_BUCKET}-${self:provider.stage}
     region: ${self:provider.region}
   iamRoleStatements:
     - Effect: "Allow"


### PR DESCRIPTION
## What did you implement:

Properly use the Serverless CLI variables and use those to set the bucket name.

## How did you implement it:

Changed a few variables.

## How can we verify it:

Check `serverless.yml`.

## Todos:

- [ ] ~~Write tests~~
- [ ] ~~Write documentation~~
- [ ] ~~Fix linting errors~~
- [ ] ~~Tag `ready for review` or `wip`~~

***Is this a breaking change?:*** NO
