### PR TITLE
Remove Package Storage Bucket

### DIFF
--- a/.serverless_plugins/remove-storage/index.js
+++ b/.serverless_plugins/remove-storage/index.js
@@ -1,8 +1,6 @@
 class RemoveStorageBucket {
-  constructor(serverless, options) {
+  constructor(serverless) {
     this.serverless = serverless;
-    this.options = options;
-
     this.provider = this.serverless.getProvider('aws');
 
     this.hooks = {
@@ -11,22 +9,28 @@ class RemoveStorageBucket {
   }
 
   beforeRemove() {
-    const s3 = new this.provider.sdk.S3({});
+    return new Promise((resolve, reject) => {
+      const s3 = new this.provider.sdk.S3({});
 
-    const bucket = this.serverless.service.resources
-    .Resources
-    .PackageStorage
-    .Properties
-    .BucketName;
+      const bucket = this.serverless.service.resources
+      .Resources
+      .PackageStorage
+      .Properties
+      .BucketName;
 
-    s3
-    .deleteBucket({
-      Bucket: bucket,
-    }).promise()
-    .then(() => {
-      this.serverless.cli.log('AWS Package Storage Removed');
-    })
-    .catch(err => this.serverless.cli.log(`Could not remove AWS package storage: ${err.message}`));
+      return s3
+      .deleteBucket({
+        Bucket: bucket,
+      }).promise()
+      .then(() => {
+        this.serverless.cli.log('AWS Package Storage Removed');
+        resolve();
+      })
+      .catch((err) => {
+        this.serverless.cli.log(`Could not remove AWS package storage: ${err.message}`);
+        reject(err);
+      });
+    });
   }
 }
 

--- a/.serverless_plugins/remove-storage/index.js
+++ b/.serverless_plugins/remove-storage/index.js
@@ -2,29 +2,58 @@ class RemoveStorageBucket {
   constructor(serverless) {
     this.serverless = serverless;
     this.provider = this.serverless.getProvider('aws');
+    this.s3 = new this.provider.sdk.S3({});
+    this.bucket = this.serverless.service.resources
+      .Resources
+      .PackageStorage
+      .Properties
+      .BucketName;
 
     this.hooks = {
       'before:remove:remove': this.beforeRemove.bind(this),
     };
   }
 
+  listAllKeys(marker) {
+    const allKeys = [];
+    return this.s3.listObjects({
+      Bucket: this.bucket,
+      Marker: marker,
+    }).promise()
+   .then((data) => {
+      allKeys.push(data.Contents);
+
+      if (data.IsTruncated) {
+        return this.listAllKeys(data.NextMarker);
+      }
+
+      return [].concat.apply([], allKeys).map(
+        ({ Key }) => ({ Key })
+      );
+    })
+  }
+
   beforeRemove() {
     return new Promise((resolve, reject) => {
-      const s3 = new this.provider.sdk.S3({});
-
-      const bucket = this.serverless.service.resources
-      .Resources
-      .PackageStorage
-      .Properties
-      .BucketName;
-
-      return s3
-      .deleteBucket({
-        Bucket: bucket,
-      }).promise()
-      .then(() => {
-        this.serverless.cli.log('AWS Package Storage Removed');
-        resolve();
+      return this.listAllKeys()
+      .then((keys) => {
+        return this.s3
+        .deleteObjects({
+          Bucket: this.bucket,
+          Delete: {
+            Objects: keys,
+          },
+        }).promise()
+        .then(() => {
+          return this.s3
+          .deleteBucket({
+            Bucket: this.bucket,
+          }).promise()
+          .then(() => {
+            this.serverless.cli.log('AWS Package Storage Removed');
+            resolve();
+          })
+        })
       })
       .catch((err) => {
         this.serverless.cli.log(`Could not remove AWS package storage: ${err.message}`);

--- a/.serverless_plugins/remove-storage/index.js
+++ b/.serverless_plugins/remove-storage/index.js
@@ -1,0 +1,33 @@
+class RemoveStorageBucket {
+  constructor(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    this.provider = this.serverless.getProvider('aws');
+
+    this.hooks = {
+      'before:remove:remove': this.beforeRemove.bind(this),
+    };
+  }
+
+  beforeRemove() {
+    const s3 = new this.provider.sdk.S3({});
+
+    const bucket = this.serverless.service.resources
+    .Resources
+    .PackageStorage
+    .Properties
+    .BucketName;
+
+    s3
+    .deleteBucket({
+      Bucket: bucket,
+    }).promise()
+    .then(() => {
+      this.serverless.cli.log('AWS Package Storage Removed');
+    })
+    .catch(err => this.serverless.cli.log(`Could not remove AWS package storage: ${err.message}`));
+  }
+}
+
+module.exports = RemoveStorageBucket;

--- a/.serverless_plugins/remove-storage/index.js
+++ b/.serverless_plugins/remove-storage/index.js
@@ -2,7 +2,9 @@ class RemoveStorageBucket {
   constructor(serverless) {
     this.serverless = serverless;
     this.provider = this.serverless.getProvider('aws');
-    this.s3 = new this.provider.sdk.S3({});
+    this.s3 = new this.provider.sdk.S3({
+      signatureVersion: 'v4',
+    });
     this.bucket = this.serverless.service.resources
       .Resources
       .PackageStorage

--- a/.serverless_plugins/remove-storage/index.js
+++ b/.serverless_plugins/remove-storage/index.js
@@ -16,17 +16,17 @@ class RemoveStorageBucket {
     };
   }
 
-  listAllKeys(marker) {
+  listAllKeys(token) {
     const allKeys = [];
-    return this.s3.listObjects({
+    return this.s3.listObjectsV2({
       Bucket: this.bucket,
-      Marker: marker,
+      ContinuationToken: token,
     }).promise()
    .then((data) => {
       allKeys.push(data.Contents);
 
       if (data.IsTruncated) {
-        return this.listAllKeys(data.NextMarker);
+        return this.listAllKeys(data.NextContinuationToken);
       }
 
       return [].concat.apply([], allKeys).map(

--- a/integration/bin/deploy
+++ b/integration/bin/deploy
@@ -18,12 +18,7 @@ const slsDeploy = spawn('sls', ['deploy', '--stage', stage]);
 
 let registryUrl;
 
-slsDeploy.stderr.on('data', (data) => {
-  console.log('Error:', data.toString());
-});
-
 slsDeploy.stdout.on('data', (data) => {
-  console.log(data.toString());
   if (!registryUrl) {
     const registryRegex = new RegExp('https://.+?(?={name})');
     const urls = registryRegex.exec(data.toString());
@@ -37,10 +32,10 @@ slsDeploy.stdout.on('data', (data) => {
   }
 });
 
-slsDeploy.on('close', (code) => {
+slsDeploy.on('exit', (code) => {
   if (code === 0) {
     console.log(`Finished deployment for yith ${stage} : code ${code}`);
   } else {
-    throw new Error(code);
+    console.log(`Error deploying code ${code}`);
   }
 });

--- a/integration/bin/deploy
+++ b/integration/bin/deploy
@@ -23,6 +23,7 @@ slsDeploy.stderr.on('data', (data) => {
 });
 
 slsDeploy.stdout.on('data', (data) => {
+  console.log(data.toString());
   if (!registryUrl) {
     const registryRegex = new RegExp('https://.+?(?={name})');
     const urls = registryRegex.exec(data.toString());

--- a/integration/helpers.js
+++ b/integration/helpers.js
@@ -2,7 +2,9 @@
 import AWS from 'aws-sdk';
 import { execFile as exec } from 'child_process';
 
-const S3 = new AWS.S3();
+const S3 = new AWS.S3({
+  signatureVersion: 'v4',
+});
 
 export default {
   package: {

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,6 +2,7 @@ frameworkVersion: '=1.6.1'
 
 plugins:
   - environment-variables
+  - remove-storage
   - serverless-webpack
   - content-handling
 

--- a/src/adapters/s3.js
+++ b/src/adapters/s3.js
@@ -3,6 +3,7 @@ import AWS from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependenc
 export default class Storage {
   constructor({ region, bucket }) {
     this.S3 = new AWS.S3({
+      signatureVersion: 'v4',
       region,
       params: {
         Bucket: bucket,

--- a/test/serverless_plugins/remove-storage/index.test.js
+++ b/test/serverless_plugins/remove-storage/index.test.js
@@ -1,0 +1,113 @@
+/* eslint-disable no-underscore-dangle */
+import AWS from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependencies
+import RemoveStorageBucket from '../../../.serverless_plugins/remove-storage';
+
+describe('Plugin: RemoveStorageBucket', () => {
+  describe('#beforeRemove()', () => {
+    context('success', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let deleteBucketStub;
+
+      beforeEach(() => {
+        serverlessLogStub = stub();
+        serverlessStub = {
+          getProvider: () => ({
+            sdk: {
+              S3: spy(() => {
+                deleteBucketStub = stub().returns({ promise: () => Promise.resolve() });
+
+                const awsS3Instance = createStubInstance(AWS.S3);
+                awsS3Instance.deleteBucket = deleteBucketStub;
+
+                return awsS3Instance;
+              }),
+            },
+          }),
+          cli: {
+            log: serverlessLogStub,
+          },
+          service: {
+            resources: {
+              Resources: {
+                PackageStorage: {
+                  Properties: {
+                    BucketName: 'foo-bucket',
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        subject = new RemoveStorageBucket(serverlessStub);
+      });
+
+      it('should call aws delete bucket correctly', async () => {
+        await subject.beforeRemove();
+
+        assert(deleteBucketStub.calledWithExactly({
+          Bucket: 'foo-bucket',
+        }));
+      });
+
+      it('should log it was a success', async () => {
+        await subject.beforeRemove();
+
+        assert(serverlessLogStub.calledWithExactly('AWS Package Storage Removed'));
+      });
+    });
+
+    context('error', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let deleteBucketStub;
+
+      beforeEach(() => {
+        serverlessLogStub = stub();
+        serverlessStub = {
+          getProvider: () => ({
+            sdk: {
+              S3: spy(() => {
+                deleteBucketStub = stub().returns({
+                  promise: () => Promise.reject(new Error('Removal Error')),
+                });
+
+                const awsS3Instance = createStubInstance(AWS.S3);
+                awsS3Instance.deleteBucket = deleteBucketStub;
+
+                return awsS3Instance;
+              }),
+            },
+          }),
+          cli: {
+            log: serverlessLogStub,
+          },
+          service: {
+            resources: {
+              Resources: {
+                PackageStorage: {
+                  Properties: {
+                    BucketName: 'foo-bucket',
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        subject = new RemoveStorageBucket(serverlessStub);
+      });
+
+      it('should log error correctly', async () => {
+        try {
+          await subject.beforeRemove();
+        } catch (err) {
+          assert(serverlessLogStub.calledWithExactly('Could not remove AWS package storage: Removal Error'));
+        }
+      });
+    });
+  });
+});

--- a/test/serverless_plugins/remove-storage/index.test.js
+++ b/test/serverless_plugins/remove-storage/index.test.js
@@ -40,7 +40,7 @@ describe('Plugin: RemoveStorageBucket', () => {
 
                 const awsS3Instance = createStubInstance(AWS.S3);
                 awsS3Instance.deleteBucket = deleteBucketStub;
-                awsS3Instance.listObjects = listObjectsStub;
+                awsS3Instance.listObjectsV2 = listObjectsStub;
                 awsS3Instance.deleteObjects = deleteObjectsStub;
 
                 return awsS3Instance;
@@ -71,7 +71,7 @@ describe('Plugin: RemoveStorageBucket', () => {
 
         assert(listObjectsStub.calledWithExactly({
           Bucket: 'foo-bucket',
-          Marker: undefined,
+          ContinuationToken: undefined,
         }));
       });
 
@@ -123,7 +123,7 @@ describe('Plugin: RemoveStorageBucket', () => {
                 });
 
                 const awsS3Instance = createStubInstance(AWS.S3);
-                awsS3Instance.listObjects = listObjectsStub;
+                awsS3Instance.listObjectsV2 = listObjectsStub;
 
                 return awsS3Instance;
               }),


### PR DESCRIPTION
## What did you implement:

Closes #34 

Added pre hook upon `sls remove` command to delete package storage bucket first.  This ensures a clean removal every time when packages have been published.

## How did you implement it:

* Added `RemoveStorageBucket` plugin to `.serverless_plugins`
* Added a test to cover the running o new plugin

## How can we verify it:

* `sls deploy --stage issue34`
* Publish a package to deployed registry
* `sls remove --stage issue34`

## Todos:
~~[ ] Tag `ready for review` or `wip`~~
~~[ ] Write documentation~~
- [x] List all objects using AWS SDK in deployed bucket
- [x] Use `deleteObjects` to clear out bucket before deleting it
- [x] Write tests
- [x] Fix linting errors

***Is this a breaking change?:*** NO
