### PR TITLE
Logging / Custom Loggers

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,3 +8,4 @@ globals:
   stub: true
   spy: true
   createStubInstance: true
+  useFakeTimers: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 .DS_Store
-*log*
+*.log*
 coverage
 .webpack
 .serverless

--- a/.serverless_plugins/log-topic/index.js
+++ b/.serverless_plugins/log-topic/index.js
@@ -1,0 +1,36 @@
+class LogTopic {
+  constructor(serverless) {
+    this.serverless = serverless;
+
+    this.topicName = `${this.serverless.service.service}-${this.serverless.processedInput.options.stage}-log`;
+    this.provider = this.serverless.getProvider('aws');
+    this.sns = new this.provider.sdk.SNS({
+      signatureVersion: 'v4',
+      region: process.env.YITH_REGION,
+    });
+
+    this.hooks = {
+      'before:deploy:compileFunctions': this.beforeDeploy.bind(this),
+    };
+  }
+
+  beforeDeploy() {
+    return new Promise((resolve, reject) => {
+      return this.sns
+      .createTopic({
+        Name: this.topicName,
+      }).promise()
+      .then((result) => {
+        this.serverless.service.provider.environment.logTopic = result.TopicArn;
+        this.serverless.cli.log(`AWS Logging SNS Topic Created ${result.TopicArn}`);
+        resolve();
+      })
+      .catch((err) => {
+        this.serverless.cli.log(`Could not create AWS Logging SNS Topic: ${err.message}`);
+        reject(err);
+      });
+    });
+  }
+}
+
+module.exports = LogTopic;

--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ echo "$NPM_REGISTRY_LOGIN_URL:_authToken=$NPM_AUTH_TOKEN" >> .npmrc
 **Note:**
 You can then reuse this build step for all of your repositories using your private npm registry.
 
+## Logging
+Upon deploying yith will create a new SNS Topic specifically for logging.  The console will log the SNS topic ARN you can use to create your own loggers using [Serverless](https://serverless.com/). Deploy your log functions into the same account and you can log with whatever tool you wish.  We hope to use this to drive a live web interface plotting npm usage within your company.
+
+An example of using slack to log activity and errors can be found here:
+[https://github.com/craftship/yith-log-slack](https://github.com/craftship/yith-log-slack)
+
 ## Other Resources
 
 [Blog](https://craftship.io/open/source/serverless/private/npm/registry/yith/2016/09/26/serverless-yith.html)

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,6 +4,7 @@ plugins:
   - environment-variables
   - remove-storage
   - serverless-webpack
+  - log-topic
   - content-handling
 
 service: yith
@@ -30,9 +31,10 @@ provider:
         - "logs:CreateLogGroup"
         - "logs:CreateLogStream"
         - "logs:PutLogEvents"
-        - "apigateway:POST"
+        - "sns:Publish"
       Resource:
         - "arn:aws:s3:::${self:provider.environment.bucket}*"
+        - "arn:aws:sns:*"
         - "arn:aws:apigateway:*"
 
 functions:

--- a/src/adapters/logger.js
+++ b/src/adapters/logger.js
@@ -1,0 +1,45 @@
+import AWS from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependencies
+
+export default class Logger {
+  constructor(namespace, { region, topic }) {
+    this.namespace = namespace;
+    this.topic = topic;
+
+    this.SNS = new AWS.SNS({
+      signatureVersion: 'v4',
+      region,
+    });
+  }
+
+  async publish(json) {
+    return this.SNS.publish({
+      Message: JSON.stringify(json),
+      TopicArn: this.topic,
+    }).promise();
+  }
+
+  async error({ stack, message }) {
+    const json = {
+      timestamp: new Date(),
+      level: 'error',
+      namespace: `error:${this.namespace}`,
+      body: {
+        message,
+        stack,
+      },
+    };
+
+    return this.publish(json);
+  }
+
+  async info(message) {
+    const json = {
+      timestamp: new Date(),
+      level: 'info',
+      namespace: `info:${this.namespace}`,
+      body: message,
+    };
+
+    return this.publish(json);
+  }
+}

--- a/src/dist-tags/put.js
+++ b/src/dist-tags/put.js
@@ -1,19 +1,31 @@
 import S3 from '../adapters/s3';
+import Logger from '../adapters/logger';
 
 export default async ({ body, pathParameters }, context, callback) => {
-  const { bucket, region } = process.env;
-  const name = `${decodeURIComponent(pathParameters.name)}`;
+  const { bucket, region, logTopic } = process.env;
   const storage = new S3({ region, bucket });
+  const log = new Logger('dist-tags:put', { region, topic: logTopic });
+
+  const name = `${decodeURIComponent(pathParameters.name)}`;
 
   try {
     const pkgBuffer = await storage.get(`${name}/index.json`);
     const json = JSON.parse(pkgBuffer.toString());
-    json['dist-tags'][pathParameters.tag] = body.replace(/"/g, '');
+    const version = body.replace(/"/g, '');
+
+    json['dist-tags'][pathParameters.tag] = version;
 
     await storage.put(
       `${name}/index.json`,
       JSON.stringify(json),
     );
+
+    await log.info({
+      name: json.name,
+      tag: pathParameters.tag,
+      version,
+      'dist-tags': json['dist-tags'],
+    });
 
     return callback(null, {
       statusCode: 200,
@@ -24,6 +36,8 @@ export default async ({ body, pathParameters }, context, callback) => {
       }),
     });
   } catch (storageError) {
+    await log.error(storageError);
+
     return callback(null, {
       statusCode: 500,
       body: JSON.stringify({

--- a/src/get.js
+++ b/src/get.js
@@ -1,10 +1,13 @@
 import npm from './adapters/npm';
 import S3 from './adapters/s3';
+import Logger from './adapters/logger';
 
-export default async ({ pathParameters }, context, callback) => {
-  const { registry, bucket, region } = process.env;
-  const name = `${decodeURIComponent(pathParameters.name)}`;
+export default async (event, context, callback) => {
+  const { registry, bucket, region, logTopic } = process.env;
   const storage = new S3({ region, bucket });
+  const log = new Logger('package:get', { region, topic: logTopic });
+
+  const name = `${decodeURIComponent(event.pathParameters.name)}`;
 
   try {
     const pkgBuffer = await storage.get(`${name}/index.json`);
@@ -16,12 +19,15 @@ export default async ({ pathParameters }, context, callback) => {
   } catch (storageError) {
     if (storageError.code === 'NoSuchKey') {
       try {
-        const data = await npm.package(registry, pathParameters.name);
+        const data = await npm.package(registry, event.pathParameters.name);
+
         return callback(null, {
           statusCode: 200,
           body: JSON.stringify(data),
         });
       } catch (npmError) {
+        await log.error(npmError);
+
         return callback(null, {
           statusCode: npmError.status,
           body: JSON.stringify({
@@ -30,6 +36,8 @@ export default async ({ pathParameters }, context, callback) => {
         });
       }
     }
+
+    await log.error(storageError);
 
     return callback(null, {
       statusCode: 500,

--- a/src/tar/get.js
+++ b/src/tar/get.js
@@ -1,11 +1,14 @@
 import npm from '../adapters/npm';
 import S3 from '../adapters/s3';
+import Logger from '../adapters/logger';
 
 export default async (event, context, callback) => {
-  const { registry, bucket, region } = process.env;
+  const { registry, bucket, region, logTopic } = process.env;
+  const storage = new S3({ region, bucket });
+  const log = new Logger('tar:get', { region, topic: logTopic });
+
   const name = `${decodeURIComponent(event.name)}`;
   const tarName = `${decodeURIComponent(event.tar)}`;
-  const storage = new S3({ region, bucket });
 
   try {
     const fileName = tarName.replace(`${name}-`, '');
@@ -21,6 +24,8 @@ export default async (event, context, callback) => {
         return callback(npmError);
       }
     }
+
+    await log.error(storageError);
 
     return callback(storageError);
   }

--- a/test/adapters/logger.test.js
+++ b/test/adapters/logger.test.js
@@ -1,0 +1,66 @@
+/* eslint-disable no-underscore-dangle */
+import AWS from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependencies
+import Subject from '../../src/adapters/logger';
+
+describe('Logger', () => {
+  let clock;
+  let awsSpy;
+  let publishStub;
+
+  beforeEach(() => {
+    awsSpy = {
+      SNS: spy(() => {
+        publishStub = stub().returns({ promise: () => Promise.resolve() });
+
+        const awsSNSInstance = createStubInstance(AWS.S3);
+        awsSNSInstance.publish = publishStub;
+
+        return awsSNSInstance;
+      }),
+    };
+
+    clock = useFakeTimers();
+
+    Subject.__Rewire__('AWS', awsSpy);
+  });
+
+  describe('#info()', () => {
+    it('should call AWS with correct parameters', async () => {
+      const subject = new Subject('foo:bar', {
+        region: 'foo-region',
+        topic: 'bar-topic',
+      });
+
+      await subject.info({ foo: 'bar' });
+
+      assert(publishStub.calledWithExactly({
+        Message: '{"timestamp":"1970-01-01T00:00:00.000Z","level":"info","namespace":"info:foo:bar","body":{"foo":"bar"}}',
+        TopicArn: 'bar-topic',
+      }));
+    });
+  });
+
+  describe('#error()', () => {
+    it('should call AWS with correct parameters', async () => {
+      const subject = new Subject('foo:bar', {
+        region: 'foo-region',
+        topic: 'bar-topic',
+      });
+
+      const expectedError = new Error('Foo Bar');
+      expectedError.stack = 'foo bar stack';
+
+      await subject.error(expectedError);
+
+      assert(publishStub.calledWithExactly({
+        Message: '{"timestamp":"1970-01-01T00:00:00.000Z","level":"error","namespace":"error:foo:bar","body":{"message":"Foo Bar","stack":"foo bar stack"}}',
+        TopicArn: 'bar-topic',
+      }));
+    });
+  });
+
+  afterEach(() => {
+    clock.restore();
+    Subject.__ResetDependency__('AWS');
+  });
+});

--- a/test/dist-tags/delete.test.js
+++ b/test/dist-tags/delete.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import Storage from '../../src/adapters/s3';
+import Logger from '../../src/adapters/logger';
 import pkg from '../fixtures/package';
 
 import subject from '../../src/dist-tags/delete';
@@ -9,6 +10,8 @@ describe('DELETE registry/-/package/{name}/dist-tags/{tag}', () => {
   let callback;
   let storageSpy;
   let storageInstance;
+  let loggerSpy;
+  let loggerInstance;
 
   beforeEach(() => {
     const env = {
@@ -18,6 +21,15 @@ describe('DELETE registry/-/package/{name}/dist-tags/{tag}', () => {
 
     process.env = env;
 
+    loggerSpy = spy(() => {
+      loggerInstance = createStubInstance(Logger);
+
+      loggerInstance.info = stub();
+      loggerInstance.error = stub();
+
+      return loggerInstance;
+    });
+
     event = {
       pathParameters: {
         name: 'foo-bar-package',
@@ -26,6 +38,8 @@ describe('DELETE registry/-/package/{name}/dist-tags/{tag}', () => {
     };
 
     callback = stub();
+
+    subject.__Rewire__('Logger', loggerSpy);
   });
 
   describe('dist-tags rm', () => {
@@ -115,5 +129,9 @@ describe('DELETE registry/-/package/{name}/dist-tags/{tag}', () => {
         subject.__ResetDependency__('S3');
       });
     });
+  });
+
+  afterEach(() => {
+    subject.__ResetDependency__('Logger');
   });
 });

--- a/test/dist-tags/get.test.js
+++ b/test/dist-tags/get.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import Storage from '../../src/adapters/s3';
+import Logger from '../../src/adapters/logger';
 import pkg from '../fixtures/package';
 
 import subject from '../../src/dist-tags/get';
@@ -9,6 +10,8 @@ describe('GET /registry/-/package/{name}/dist-tags', () => {
   let callback;
   let storageSpy;
   let storageInstance;
+  let loggerInstance;
+  let loggerSpy;
 
   beforeEach(() => {
     const env = {
@@ -19,6 +22,15 @@ describe('GET /registry/-/package/{name}/dist-tags', () => {
 
     process.env = env;
 
+    loggerSpy = spy(() => {
+      loggerInstance = createStubInstance(Logger);
+
+      loggerInstance.info = stub();
+      loggerInstance.error = stub();
+
+      return loggerInstance;
+    });
+
     event = {
       pathParameters: {
         name: 'foo-bar-package',
@@ -26,6 +38,8 @@ describe('GET /registry/-/package/{name}/dist-tags', () => {
     };
 
     callback = stub();
+
+    subject.__Rewire__('Logger', loggerSpy);
   });
 
   describe('dist-tags ls', () => {
@@ -191,5 +205,9 @@ describe('GET /registry/-/package/{name}/dist-tags', () => {
         subject.__ResetDependency__('S3');
       });
     });
+  });
+
+  afterEach(() => {
+    subject.__ResetDependency__('Logger');
   });
 });

--- a/test/dist-tags/put.test.js
+++ b/test/dist-tags/put.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import Storage from '../../src/adapters/s3';
+import Logger from '../../src/adapters/logger';
 import pkg from '../fixtures/package';
 
 import subject from '../../src/dist-tags/put';
@@ -9,6 +10,8 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
   let callback;
   let storageSpy;
   let storageInstance;
+  let loggerInstance;
+  let loggerSpy;
 
   beforeEach(() => {
     const env = {
@@ -17,6 +20,15 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
     };
 
     process.env = env;
+
+    loggerSpy = spy(() => {
+      loggerInstance = createStubInstance(Logger);
+
+      loggerInstance.info = stub();
+      loggerInstance.error = stub();
+
+      return loggerInstance;
+    });
 
     event = {
       pathParameters: {
@@ -29,6 +41,8 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
     };
 
     callback = stub();
+
+    subject.__Rewire__('Logger', loggerSpy);
   });
 
   describe('dist-tags add', () => {
@@ -132,5 +146,9 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
         subject.__ResetDependency__('S3');
       });
     });
+  });
+
+  afterEach(() => {
+    subject.__ResetDependency__('Logger');
   });
 });

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import Storage from '../src/adapters/s3';
+import Logger from '../src/adapters/logger';
 import pkg from './fixtures/package';
 
 import subject from '../src/get';
@@ -9,6 +10,8 @@ describe('GET /registry/{name}', () => {
   let callback;
   let storageSpy;
   let storageInstance;
+  let loggerInstance;
+  let loggerSpy;
 
   beforeEach(() => {
     const env = {
@@ -19,6 +22,15 @@ describe('GET /registry/{name}', () => {
 
     process.env = env;
 
+    loggerSpy = spy(() => {
+      loggerInstance = createStubInstance(Logger);
+
+      loggerInstance.info = stub();
+      loggerInstance.error = stub();
+
+      return loggerInstance;
+    });
+
     event = {
       pathParameters: {
         name: 'foo-bar-package',
@@ -26,6 +38,8 @@ describe('GET /registry/{name}', () => {
     };
 
     callback = stub();
+
+    subject.__Rewire__('Logger', loggerSpy);
   });
 
   context('package does not exist in private registry', () => {
@@ -201,5 +215,9 @@ describe('GET /registry/{name}', () => {
       subject.__ResetDependency__('npm');
       subject.__ResetDependency__('S3');
     });
+  });
+
+  afterEach(() => {
+    subject.__ResetDependency__('Logger');
   });
 });

--- a/test/globals.js
+++ b/test/globals.js
@@ -4,4 +4,5 @@ const sinon = require('sinon');
 global.assert = assert;
 global.stub = sinon.stub;
 global.spy = sinon.spy;
+global.useFakeTimers = sinon.useFakeTimers;
 global.createStubInstance = sinon.createStubInstance;

--- a/test/put.test.js
+++ b/test/put.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import Storage from '../src/adapters/s3';
+import Logger from '../src/adapters/logger';
 import pkg from './fixtures/package';
 
 import subject from '../src/put';
@@ -9,6 +10,8 @@ describe('PUT /registry/{name}', () => {
   let callback;
   let storageSpy;
   let storageInstance;
+  let loggerSpy;
+  let loggerInstance;
 
   beforeEach(() => {
     const env = {
@@ -18,6 +21,14 @@ describe('PUT /registry/{name}', () => {
 
     process.env = env;
 
+    loggerSpy = spy(() => {
+      loggerInstance = createStubInstance(Logger);
+
+      loggerInstance.info = stub();
+      loggerInstance.error = stub();
+      return loggerInstance;
+    });
+
     event = version => ({
       body: pkg(version),
       pathParameters: {
@@ -26,6 +37,8 @@ describe('PUT /registry/{name}', () => {
     });
 
     callback = stub();
+
+    subject.__Rewire__('Logger', loggerSpy);
   });
 
   describe('publish', () => {
@@ -291,5 +304,9 @@ describe('PUT /registry/{name}', () => {
         subject.__ResetDependency__('S3');
       });
     });
+  });
+
+  afterEach(() => {
+    subject.__ResetDependency__('Logger');
   });
 });

--- a/test/serverless_plugins/log-topic/index.test.js
+++ b/test/serverless_plugins/log-topic/index.test.js
@@ -1,0 +1,110 @@
+/* eslint-disable no-underscore-dangle */
+import AWS from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependencies
+import LogTopic from '../../../.serverless_plugins/log-topic';
+
+describe('Plugin: LogTopic', () => {
+  const createServerlessStub = (SNS, log) => ({
+    getProvider: () => ({
+      sdk: {
+        SNS,
+      },
+    }),
+    service: {
+      provider: {
+        environment: stub(),
+      },
+      service: 'foo',
+    },
+    processedInput: {
+      options: {
+        stage: 'bar',
+      },
+    },
+    cli: {
+      log,
+    },
+  });
+
+  describe('#beforeDeploy()', () => {
+    context('success', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let createTopicStub;
+
+      beforeEach(() => {
+        serverlessLogStub = stub();
+        serverlessStub = createServerlessStub(
+          spy(() => {
+            createTopicStub = stub().returns({
+              promise: () => Promise.resolve({ TopicArn: 'foo-bar-arn' }),
+            });
+
+            const awsSNSInstance = createStubInstance(AWS.SNS);
+            awsSNSInstance.createTopic = createTopicStub;
+
+            return awsSNSInstance;
+          }), serverlessLogStub);
+
+        subject = new LogTopic(serverlessStub);
+      });
+
+      it('should create topic correctly', async () => {
+        await subject.beforeDeploy();
+
+        assert(createTopicStub.calledWithExactly({
+          Name: 'foo-bar-log',
+        }));
+      });
+
+      it('should set environment variable logTopic', async () => {
+        await subject.beforeDeploy();
+
+        assert(serverlessStub
+         .service
+         .provider
+         .environment
+         .logTopic === 'foo-bar-arn',
+        );
+      });
+
+      it('should log success', async () => {
+        await subject.beforeDeploy();
+
+        assert(serverlessLogStub.calledWithExactly('AWS Logging SNS Topic Created foo-bar-arn'));
+      });
+    });
+
+    context('error', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let createTopicStub;
+
+      beforeEach(() => {
+        serverlessLogStub = stub();
+        serverlessStub = createServerlessStub(
+          spy(() => {
+            createTopicStub = stub().returns({
+              promise: () => Promise.reject(new Error('Create Failed')),
+            });
+
+            const awsSNSInstance = createStubInstance(AWS.SNS);
+            awsSNSInstance.createTopic = createTopicStub;
+
+            return awsSNSInstance;
+          }), serverlessLogStub);
+
+        subject = new LogTopic(serverlessStub);
+      });
+
+      it('should log error', async () => {
+        try {
+          await subject.beforeDeploy();
+        } catch (err) {
+          assert(serverlessLogStub.calledWithExactly('Could not create AWS Logging SNS Topic: Create Failed'));
+        }
+      });
+    });
+  });
+});

--- a/test/tar/get.test.js
+++ b/test/tar/get.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import Storage from '../../src/adapters/s3';
+import Logger from '../../src/adapters/logger';
 import subject from '../../src/tar/get';
 
 describe('GET /registry/{name}/-/{tar}', () => {
@@ -7,6 +8,8 @@ describe('GET /registry/{name}/-/{tar}', () => {
   let callback;
   let storageSpy;
   let storageInstance;
+  let loggerInstance;
+  let loggerSpy;
 
   beforeEach(() => {
     const env = {
@@ -17,12 +20,23 @@ describe('GET /registry/{name}/-/{tar}', () => {
 
     process.env = env;
 
+    loggerSpy = spy(() => {
+      loggerInstance = createStubInstance(Logger);
+
+      loggerInstance.info = stub();
+      loggerInstance.error = stub();
+
+      return loggerInstance;
+    });
+
     event = {
       name: 'foo-bar-package',
       tar: 'foo-bar-package-1.0.0.tgz',
     };
 
     callback = stub();
+
+    subject.__Rewire__('Logger', loggerSpy);
   });
 
   context('tar exists in private registry', () => {
@@ -137,5 +151,9 @@ describe('GET /registry/{name}/-/{tar}', () => {
     afterEach(() => {
       subject.__ResetDependency__('S3');
     });
+  });
+
+  afterEach(() => {
+    subject.__ResetDependency__('Logger');
   });
 });


### PR DESCRIPTION
## What did you implement:

This features allows people to create their own logging functions and deploy them to AWS.  All that is required is for people to create a new Serverless service that points to the log topic (SNS Topic ARN) which is now created upon deploying yith and outputted in the console.

Each log event is namespaced so that you can do different messages and log differently according to your requirements.

A very quick example of a slack logger can be found at:
https://github.com/craftship/yith-log-slack

This logs events and more importantly if any errors occur plus the stack trace, no more hunting in `CloudWatch`!

Hopefully the community can create loggers for things such as loggly, newrelic or anything else they can think off.  This will come in handy once the user interface is built, hoping to get live graphs plotting activity as it happens.

## How did you implement it:

* Created a new plugin to create an SNS topic and set an environment variable `logTopic` for its ARN that can be used within functions (could not figure out how to do this using `serverless.yaml` resources
* Created a new adapter called `logger` that publishes messages to an SNS topic
* Updated specs to stub out the logger class

## How can we verify it:

* `npm t`
* Deploy `yith` into an environment
* Deploy `yith-log-slack` into same environment with relevant token and channel setup

Example Output for Slack Logger:


![image](https://cloud.githubusercontent.com/assets/430934/22863182/76c045b2-f133-11e6-83cd-834e21e0990f.png)

## Todos:

~~Tag `ready for review` or `wip`~~
- [x] Write documentation
- [x] Fix linting errors
- [x] Write tests

***Is this a breaking change?:*** NO
