### PR TITLE
Package GET: Remove Attachments

### DIFF
--- a/src/get.js
+++ b/src/get.js
@@ -11,10 +11,12 @@ export default async (event, context, callback) => {
 
   try {
     const pkgBuffer = await storage.get(`${name}/index.json`);
+    const json = JSON.parse(pkgBuffer.toString());
+    json._attachments = {}; // eslint-disable-line no-underscore-dangle
 
     return callback(null, {
       statusCode: 200,
-      body: pkgBuffer.toString(),
+      body: JSON.stringify(json),
     });
   } catch (storageError) {
     if (storageError.code === 'NoSuchKey') {

--- a/test/dist-tags/delete.test.js
+++ b/test/dist-tags/delete.test.js
@@ -48,7 +48,7 @@ describe('DELETE registry/-/package/{name}/dist-tags/{tag}', () => {
         storageSpy = spy(() => {
           storageInstance = createStubInstance(Storage);
 
-          const pkgDistTags = JSON.parse(pkg({
+          const pkgDistTags = JSON.parse(pkg.withAttachments({
             major: 1,
             minor: 0,
             patch: 0,
@@ -79,7 +79,7 @@ describe('DELETE registry/-/package/{name}/dist-tags/{tag}', () => {
 
         assert(storageInstance.put.calledWithExactly(
           'foo-bar-package/index.json',
-          pkg({ major: 1, minor: 0, patch: 0 }).toString(),
+          pkg.withAttachments({ major: 1, minor: 0, patch: 0 }).toString(),
         ));
       });
 
@@ -102,7 +102,7 @@ describe('DELETE registry/-/package/{name}/dist-tags/{tag}', () => {
         storageSpy = spy(() => {
           storageInstance = createStubInstance(Storage);
 
-          storageInstance.get.returns(pkg({
+          storageInstance.get.returns(pkg.withoutAttachments({
             major: 1,
             minor: 0,
             patch: 0,

--- a/test/dist-tags/get.test.js
+++ b/test/dist-tags/get.test.js
@@ -48,7 +48,7 @@ describe('GET /registry/-/package/{name}/dist-tags', () => {
         storageSpy = spy(() => {
           storageInstance = createStubInstance(Storage);
 
-          storageInstance.get.returns(pkg({
+          storageInstance.get.returns(pkg.withAttachments({
             major: 1,
             minor: 0,
             patch: 0,
@@ -128,7 +128,7 @@ describe('GET /registry/-/package/{name}/dist-tags', () => {
 
       beforeEach(() => {
         npmPackageStub = stub().returns(
-          JSON.parse(pkg({
+          JSON.parse(pkg.withoutAttachments({
             major: 1,
             minor: 0,
             patch: 0,

--- a/test/dist-tags/put.test.js
+++ b/test/dist-tags/put.test.js
@@ -51,7 +51,7 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
         storageSpy = spy(() => {
           storageInstance = createStubInstance(Storage);
 
-          const pkgDistTags = JSON.parse(pkg({
+          const pkgDistTags = JSON.parse(pkg.withAttachments({
             major: 1,
             minor: 0,
             patch: 0,
@@ -79,7 +79,7 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
         await subject(event, stub(), callback);
 
         const pkgInitial = JSON.parse(
-          pkg({
+          pkg.withAttachments({
             major: 1,
             minor: 0,
             patch: 0,
@@ -119,7 +119,7 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
         storageSpy = spy(() => {
           storageInstance = createStubInstance(Storage);
 
-          storageInstance.get.returns(pkg({
+          storageInstance.get.returns(pkg.withoutAttachments({
             major: 1,
             minor: 0,
             patch: 0,

--- a/test/fixtures/package.js
+++ b/test/fixtures/package.js
@@ -1,27 +1,52 @@
-export default ({
-  major,
-  minor,
-  patch,
-}) => new Buffer(
-  JSON.stringify({
-    _id: 'foo-bar-package',
-    name: 'foo-bar-package',
-    'dist-tags': {
-      latest: `${major}.${minor}.${patch}`,
-    },
-    versions: {
-      [`${major}.${minor}.${patch}`]: {
-        name: 'foo-bar-package',
-        version: `${major}.${minor}.${patch}`,
-        dist: {
-          tarball: `https://example.com/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
+export default {
+  withAttachments: ({
+    major,
+    minor,
+    patch,
+  }) => new Buffer(
+    JSON.stringify({
+      _id: 'foo-bar-package',
+      name: 'foo-bar-package',
+      'dist-tags': {
+        latest: `${major}.${minor}.${patch}`,
+      },
+      versions: {
+        [`${major}.${minor}.${patch}`]: {
+          name: 'foo-bar-package',
+          version: `${major}.${minor}.${patch}`,
+          dist: {
+            tarball: `https://example.com/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
+          },
         },
       },
-    },
-    _attachments: {
-      [`foo-bar-package-${major}.${minor}.${patch}.tgz`]: {
-        data: 'foo-package-data',
+      _attachments: {
+        [`foo-bar-package-${major}.${minor}.${patch}.tgz`]: {
+          data: 'foo-package-data',
+        },
       },
-    },
-  }),
-);
+    }),
+  ),
+  withoutAttachments: ({
+    major,
+    minor,
+    patch,
+  }) => new Buffer(
+    JSON.stringify({
+      _id: 'foo-bar-package',
+      name: 'foo-bar-package',
+      'dist-tags': {
+        latest: `${major}.${minor}.${patch}`,
+      },
+      versions: {
+        [`${major}.${minor}.${patch}`]: {
+          name: 'foo-bar-package',
+          version: `${major}.${minor}.${patch}`,
+          dist: {
+            tarball: `https://example.com/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
+          },
+        },
+      },
+      _attachments: {},
+    }),
+  ),
+};

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -47,7 +47,7 @@ describe('GET /registry/{name}', () => {
 
     beforeEach(() => {
       npmPackageStub = stub().returns(
-        JSON.parse(pkg({
+        JSON.parse(pkg.withoutAttachments({
           major: 1,
           minor: 0,
           patch: 0,
@@ -88,7 +88,7 @@ describe('GET /registry/{name}', () => {
 
       assert(callback.calledWithExactly(null, {
         statusCode: 200,
-        body: pkg({
+        body: pkg.withoutAttachments({
           major: 1,
           minor: 0,
           patch: 0,
@@ -107,7 +107,7 @@ describe('GET /registry/{name}', () => {
       storageSpy = spy(() => {
         storageInstance = createStubInstance(Storage);
 
-        storageInstance.get.returns(pkg({
+        storageInstance.get.returns(pkg.withAttachments({
           major: 1,
           minor: 0,
           patch: 0,
@@ -132,7 +132,7 @@ describe('GET /registry/{name}', () => {
 
       assert(callback.calledWithExactly(null, {
         statusCode: 200,
-        body: pkg({
+        body: pkg.withoutAttachments({
           major: 1,
           minor: 0,
           patch: 0,

--- a/test/put.test.js
+++ b/test/put.test.js
@@ -30,7 +30,7 @@ describe('PUT /registry/{name}', () => {
     });
 
     event = version => ({
-      body: pkg(version),
+      body: pkg.withAttachments(version),
       pathParameters: {
         name: 'foo-bar-package',
       },
@@ -107,7 +107,7 @@ describe('PUT /registry/{name}', () => {
 
         assert(storageInstance.put.calledWithExactly(
           'foo-bar-package/index.json',
-          pkg({
+          pkg.withAttachments({
             major: 1,
             minor: 0,
             patch: 0,
@@ -138,7 +138,7 @@ describe('PUT /registry/{name}', () => {
         storageSpy = spy(() => {
           storageInstance = createStubInstance(Storage);
 
-          storageInstance.get.returns(pkg({
+          storageInstance.get.returns(pkg.withAttachments({
             major: 1,
             minor: 0,
             patch: 0,
@@ -197,8 +197,8 @@ describe('PUT /registry/{name}', () => {
           patch: 0,
         }), stub(), callback);
 
-        const pkg1 = JSON.parse(pkg({ major: 1, minor: 0, patch: 0 }).toString());
-        const pkg2 = JSON.parse(pkg({ major: 2, minor: 0, patch: 0 }).toString());
+        const pkg1 = JSON.parse(pkg.withAttachments({ major: 1, minor: 0, patch: 0 }).toString());
+        const pkg2 = JSON.parse(pkg.withAttachments({ major: 2, minor: 0, patch: 0 }).toString());
 
         const versions = Object.assign(pkg1.versions, pkg2.versions);
         const attachments = Object.assign(pkg1._attachments, pkg2._attachments);
@@ -238,7 +238,7 @@ describe('PUT /registry/{name}', () => {
         storageSpy = spy(() => {
           storageInstance = createStubInstance(Storage);
 
-          storageInstance.get.returns(pkg({
+          storageInstance.get.returns(pkg.withAttachments({
             major: 1,
             minor: 0,
             patch: 0,
@@ -273,7 +273,7 @@ describe('PUT /registry/{name}', () => {
         storageSpy = spy(() => {
           storageInstance = createStubInstance(Storage);
 
-          storageInstance.get.returns(pkg({
+          storageInstance.get.returns(pkg.withAttachments({
             major: 1,
             minor: 0,
             patch: 0,


### PR DESCRIPTION
## What did you implement:

Closes #39 

Attachments were being returned within the json response when getting the package.  This caused with many publishes the 6MB limit to easily be hit.  This now matches the behaviour of `npm` where attachments are sent through as an empty object.

## How did you implement it:

* Get the JSON for the package and set the `_attachments` property to an empty object
* Keeping the attachments stored so that if any zip files get corrupt at least they could be restored from the `_attachments`.

## How can we verify it:

* Deploy registry
* Use registry to publish a larger package size, versioning it a few times
* Ensure json is over 6MB limit
* Attempt to install package

## Todos:

- [x] Write tests
- [x] ~~Write documentation~~
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
