### PR TITLE
Authoriser Context / Personalisation

### DIFF
--- a/src/adapters/logger.js
+++ b/src/adapters/logger.js
@@ -18,8 +18,9 @@ export default class Logger {
     }).promise();
   }
 
-  async error({ stack, message }) {
+  async error(user, { stack, message }) {
     const json = {
+      user,
       timestamp: new Date(),
       level: 'error',
       namespace: `error:${this.namespace}`,
@@ -32,8 +33,9 @@ export default class Logger {
     return this.publish(json);
   }
 
-  async info(message) {
+  async info(user, message) {
     const json = {
+      user,
       timestamp: new Date(),
       level: 'info',
       namespace: `info:${this.namespace}`,

--- a/src/dist-tags/get.js
+++ b/src/dist-tags/get.js
@@ -2,8 +2,15 @@ import npm from '../adapters/npm';
 import S3 from '../adapters/s3';
 import Logger from '../adapters/logger';
 
-export default async ({ pathParameters }, context, callback) => {
+export default async ({
+  requestContext,
+  pathParameters,
+}, context, callback) => {
   const { registry, bucket, region, logTopic } = process.env;
+  const user = {
+    name: requestContext.authorizer.username,
+    avatar: requestContext.authorizer.avatar,
+  };
   const storage = new S3({ region, bucket });
   const log = new Logger('dist-tags:get', { region, topic: logTopic });
 
@@ -35,7 +42,7 @@ export default async ({ pathParameters }, context, callback) => {
       }
     }
 
-    await log.error(storageError);
+    await log.error(user, storageError);
 
     return callback(null, {
       statusCode: 500,

--- a/src/get.js
+++ b/src/get.js
@@ -4,6 +4,10 @@ import Logger from './adapters/logger';
 
 export default async (event, context, callback) => {
   const { registry, bucket, region, logTopic } = process.env;
+  const user = {
+    name: event.requestContext.authorizer.username,
+    avatar: event.requestContext.authorizer.avatar,
+  };
   const storage = new S3({ region, bucket });
   const log = new Logger('package:get', { region, topic: logTopic });
 
@@ -39,7 +43,7 @@ export default async (event, context, callback) => {
       }
     }
 
-    await log.error(storageError);
+    await log.error(user, storageError);
 
     return callback(null, {
       statusCode: 500,

--- a/src/tar/get.js
+++ b/src/tar/get.js
@@ -25,7 +25,7 @@ export default async (event, context, callback) => {
       }
     }
 
-    await log.error(storageError);
+    await log.error(null, storageError);
 
     return callback(storageError);
   }

--- a/test/adapters/logger.test.js
+++ b/test/adapters/logger.test.js
@@ -3,11 +3,17 @@ import AWS from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependenc
 import Subject from '../../src/adapters/logger';
 
 describe('Logger', () => {
+  let user;
   let clock;
   let awsSpy;
   let publishStub;
 
   beforeEach(() => {
+    user = {
+      name: 'foo',
+      avatar: 'https://example.com',
+    };
+
     awsSpy = {
       SNS: spy(() => {
         publishStub = stub().returns({ promise: () => Promise.resolve() });
@@ -31,10 +37,10 @@ describe('Logger', () => {
         topic: 'bar-topic',
       });
 
-      await subject.info({ foo: 'bar' });
+      await subject.info(user, { foo: 'bar' });
 
       assert(publishStub.calledWithExactly({
-        Message: '{"timestamp":"1970-01-01T00:00:00.000Z","level":"info","namespace":"info:foo:bar","body":{"foo":"bar"}}',
+        Message: '{"user":{"name":"foo","avatar":"https://example.com"},"timestamp":"1970-01-01T00:00:00.000Z","level":"info","namespace":"info:foo:bar","body":{"foo":"bar"}}',
         TopicArn: 'bar-topic',
       }));
     });
@@ -50,10 +56,10 @@ describe('Logger', () => {
       const expectedError = new Error('Foo Bar');
       expectedError.stack = 'foo bar stack';
 
-      await subject.error(expectedError);
+      await subject.error(user, expectedError);
 
       assert(publishStub.calledWithExactly({
-        Message: '{"timestamp":"1970-01-01T00:00:00.000Z","level":"error","namespace":"error:foo:bar","body":{"message":"Foo Bar","stack":"foo bar stack"}}',
+        Message: '{"user":{"name":"foo","avatar":"https://example.com"},"timestamp":"1970-01-01T00:00:00.000Z","level":"error","namespace":"error:foo:bar","body":{"message":"Foo Bar","stack":"foo bar stack"}}',
         TopicArn: 'bar-topic',
       }));
     });

--- a/test/authorizers/github.test.js
+++ b/test/authorizers/github.test.js
@@ -134,7 +134,14 @@ describe('GitHub Authorizer', () => {
         gitHubSpy = spy(() => {
           gitHubInstance = createStubInstance(GitHub);
           authStub = stub();
-          checkAuthStub = stub().returns({ user: { login: 'foo-user' } });
+          checkAuthStub = stub().returns({
+            user: {
+              login: 'foo-user',
+              avatar_url: 'https://example.com',
+            },
+            created_at: '2001-01-01T00:00:00Z',
+            updated_at: '2001-02-01T00:00:00Z',
+          });
 
           gitHubInstance.authenticate = authStub;
           gitHubInstance.authorization = {
@@ -193,6 +200,12 @@ describe('GitHub Authorizer', () => {
               },
             ],
           },
+          context: {
+            username: 'foo-user',
+            avatar: 'https://example.com',
+            createdAt: '2001-01-01T00:00:00Z',
+            updatedAt: '2001-02-01T00:00:00Z',
+          },
         }));
       });
 
@@ -216,7 +229,14 @@ describe('GitHub Authorizer', () => {
         gitHubSpy = spy(() => {
           gitHubInstance = createStubInstance(GitHub);
           authStub = stub();
-          checkAuthStub = stub().returns({ user: { login: 'foo-user' } });
+          checkAuthStub = stub().returns({
+            user: {
+              login: 'foo-user',
+              avatar_url: 'https://example.com',
+            },
+            created_at: '2001-01-01T00:00:00Z',
+            updated_at: '2001-02-01T00:00:00Z',
+          });
 
           gitHubInstance.authenticate = authStub;
           gitHubInstance.authorization = {
@@ -274,6 +294,12 @@ describe('GitHub Authorizer', () => {
                 Resource: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/DELETE/registry*',
               },
             ],
+          },
+          context: {
+            username: 'foo-user',
+            avatar: 'https://example.com',
+            createdAt: '2001-01-01T00:00:00Z',
+            updatedAt: '2001-02-01T00:00:00Z',
           },
         }));
       });

--- a/test/dist-tags/delete.test.js
+++ b/test/dist-tags/delete.test.js
@@ -31,6 +31,12 @@ describe('DELETE registry/-/package/{name}/dist-tags/{tag}', () => {
     });
 
     event = {
+      requestContext: {
+        authorizer: {
+          username: 'foo',
+          avatar: 'https://example.com',
+        },
+      },
       pathParameters: {
         name: 'foo-bar-package',
         tag: 'alpha',

--- a/test/dist-tags/get.test.js
+++ b/test/dist-tags/get.test.js
@@ -32,6 +32,12 @@ describe('GET /registry/-/package/{name}/dist-tags', () => {
     });
 
     event = {
+      requestContext: {
+        authorizer: {
+          username: 'foo',
+          avatar: 'https://example.com',
+        },
+      },
       pathParameters: {
         name: 'foo-bar-package',
       },

--- a/test/dist-tags/put.test.js
+++ b/test/dist-tags/put.test.js
@@ -31,6 +31,12 @@ describe('PUT registry/-/package/{name}/dist-tags/{tag}', () => {
     });
 
     event = {
+      requestContext: {
+        authorizer: {
+          username: 'foo',
+          avatar: 'https://example.com',
+        },
+      },
       pathParameters: {
         name: 'foo-bar-package',
         tag: 'foo',

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -32,6 +32,12 @@ describe('GET /registry/{name}', () => {
     });
 
     event = {
+      requestContext: {
+        authorizer: {
+          username: 'foo',
+          avatar: 'https://example.com',
+        },
+      },
       pathParameters: {
         name: 'foo-bar-package',
       },

--- a/test/put.test.js
+++ b/test/put.test.js
@@ -30,6 +30,12 @@ describe('PUT /registry/{name}', () => {
     });
 
     event = version => ({
+      requestContext: {
+        authorizer: {
+          username: 'foo',
+          avatar: 'https://example.com',
+        },
+      },
       body: pkg.withAttachments(version),
       pathParameters: {
         name: 'foo-bar-package',


### PR DESCRIPTION
## What did you implement:

Add context from authoriser to allow for personalisation and auditing.

## How did you implement it:

* Amended the policy document to return context with relevant user information
* Amended logger to pass down user context (this is going on the "extractobonaza refactor list")

## How can we verify it:

* Run `npm t`
* Deploy a registry
* Deploy yith slack logger
* See the personalisation messages flow in, includes errors to help talk to people directly within the company

## Todos:

- [x] Write tests
- [x] ~~Write documentation~~
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
