### PR TITLE
Restrict Organizations (Public GitHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ export CODEBOX_BUCKET="my-npm-registry-storage" # The name of the bucket in whic
 export CODEBOX_GITHUB_URL="https://api.github.com/" # The GitHub / GitHub Enterprise **api** url
 export CODEBOX_GITHUB_CLIENT_ID="client_id" # The client id for your GitHub application
 export CODEBOX_GITHUB_SECRET="secret" # The secret for your GitHub application
+export CODEBOX_RESTRICTED_ORGS="" # OPTIONAL: Comma seperated list of github organisations to only allow access to users in that org (e.g. "craftship,myorg").  Useful if using public GitHub for authentication, as by default all authenticated users would have access.
 ```
 * `serverless deploy --stage prod` (pick which ever stage you wish)
 * `npm set registry <url>` - `<url>` being the base url shown in the terminal after deployment completes, such as:

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,6 +17,7 @@ provider:
   region: ${env:CODEBOX_REGION}
   environment:
     admins: ${env:CODEBOX_ADMINS}
+    restrictedOrgs: ${env:CODEBOX_RESTRICTED_ORGS}
     registry: ${env:CODEBOX_REGISTRY}
     githubUrl: ${env:CODEBOX_GITHUB_URL}
     githubClientId:  ${env:CODEBOX_GITHUB_CLIENT_ID}

--- a/src/user/put.js
+++ b/src/user/put.js
@@ -7,7 +7,7 @@ export default async ({ body }, context, callback) => {
     password,
   } = JSON.parse(body);
 
-  const scopes = ['user:email'];
+  const scopes = ['user:email', 'read:org'];
   const nameParts = name.split('.');
   const username = nameParts[0];
   const otp = nameParts.length > 1 ? nameParts[nameParts.length - 1] : '';

--- a/src/user/put.js
+++ b/src/user/put.js
@@ -7,7 +7,12 @@ export default async ({ body }, context, callback) => {
     password,
   } = JSON.parse(body);
 
-  const scopes = ['user:email', 'read:org'];
+  const scopes = ['user:email'];
+
+  if (process.env.restrictedOrgs) {
+    scopes.push('read:org');
+  }
+
   const nameParts = name.split('.');
   const username = nameParts[0];
   const otp = nameParts.length > 1 ? nameParts[nameParts.length - 1] : '';

--- a/test/authorizers/github.test.js
+++ b/test/authorizers/github.test.js
@@ -13,7 +13,6 @@ describe('GitHub Authorizer', () => {
       githubClientId: 'foo-client-id',
       githubSecret: 'bar-secret',
       githubUrl: 'https://example.com',
-      admins: '',
     };
 
     process.env = env;
@@ -119,6 +118,190 @@ describe('GitHub Authorizer', () => {
   });
 
   describe('valid access token', () => {
+    context('is in restricted org', () => {
+      let authStub;
+      let getOrgMembershipsStub;
+
+      beforeEach(() => {
+        process.env.admins = '';
+        process.env.restrictedOrgs = 'foo-org';
+
+        event = {
+          authorizationToken: 'Bearer foo-valid-token',
+          methodArn: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/GET/registry',
+        };
+
+        gitHubSpy = spy(() => {
+          gitHubInstance = createStubInstance(GitHub);
+          authStub = stub();
+          getOrgMembershipsStub = stub().returns([{
+            organization: {
+              login: 'foo-org',
+            },
+          }]);
+
+          const checkAuthStub = stub().returns({
+            user: {
+              login: 'foo-user',
+              avatar_url: 'https://example.com',
+            },
+            created_at: '2001-01-01T00:00:00Z',
+            updated_at: '2001-02-01T00:00:00Z',
+          });
+
+          gitHubInstance.authenticate = authStub;
+          gitHubInstance.authorization = {
+            check: checkAuthStub,
+          };
+          gitHubInstance.users = {
+            getOrgMemberships: getOrgMembershipsStub,
+          };
+
+          return gitHubInstance;
+        });
+
+        subject.__Rewire__({
+          GitHub: gitHubSpy,
+        });
+      });
+
+      it('should get users organizations', async () => {
+        await subject(event, stub(), callback);
+
+        assert(getOrgMembershipsStub.calledWithExactly({
+          state: 'active',
+        }));
+      });
+
+      it('should only allow get access', async () => {
+        await subject(event, stub(), callback);
+
+        assert(callback.calledWithExactly(null, {
+          principalId: 'foo-valid-token',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Action: 'execute-api:Invoke',
+                Effect: 'Allow',
+                Resource: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/GET/registry*',
+              },
+              {
+                Action: 'execute-api:Invoke',
+                Effect: 'Deny',
+                Resource: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/PUT/registry*',
+              },
+              {
+                Action: 'execute-api:Invoke',
+                Effect: 'Deny',
+                Resource: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/DELETE/registry*',
+              },
+            ],
+          },
+          context: {
+            username: 'foo-user',
+            avatar: 'https://example.com',
+            createdAt: '2001-01-01T00:00:00Z',
+            updatedAt: '2001-02-01T00:00:00Z',
+          },
+        }));
+      });
+
+      afterEach(() => {
+        subject.__ResetDependency__('GitHub');
+      });
+    });
+
+    context('not in restricted org', () => {
+      let authStub;
+      let getOrgMembershipsStub;
+
+      beforeEach(() => {
+        process.env.admins = '';
+        process.env.restrictedOrgs = 'foo-org';
+
+        event = {
+          authorizationToken: 'Bearer foo-valid-token',
+          methodArn: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/GET/registry',
+        };
+
+        gitHubSpy = spy(() => {
+          gitHubInstance = createStubInstance(GitHub);
+          authStub = stub();
+          getOrgMembershipsStub = stub().returns([]);
+
+          const checkAuthStub = stub().returns({
+            user: {
+              login: 'foo-user',
+              avatar_url: 'https://example.com',
+            },
+            created_at: '2001-01-01T00:00:00Z',
+            updated_at: '2001-02-01T00:00:00Z',
+          });
+
+          gitHubInstance.authenticate = authStub;
+          gitHubInstance.authorization = {
+            check: checkAuthStub,
+          };
+          gitHubInstance.users = {
+            getOrgMemberships: getOrgMembershipsStub,
+          };
+
+          return gitHubInstance;
+        });
+
+        subject.__Rewire__({
+          GitHub: gitHubSpy,
+        });
+      });
+
+      it('should get users organizations', async () => {
+        await subject(event, stub(), callback);
+
+        assert(getOrgMembershipsStub.calledWithExactly({
+          state: 'active',
+        }));
+      });
+
+      it('should deny get, put and delete', async () => {
+        await subject(event, stub(), callback);
+
+        assert(callback.calledWithExactly(null, {
+          principalId: 'foo-valid-token',
+          policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Action: 'execute-api:Invoke',
+                Effect: 'Deny',
+                Resource: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/GET/registry*',
+              },
+              {
+                Action: 'execute-api:Invoke',
+                Effect: 'Deny',
+                Resource: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/PUT/registry*',
+              },
+              {
+                Action: 'execute-api:Invoke',
+                Effect: 'Deny',
+                Resource: 'arn:aws:execute-api:foo-region:bar-account:baz-api/foo-stage/DELETE/registry*',
+              },
+            ],
+          },
+          context: {
+            username: 'foo-user',
+            avatar: 'https://example.com',
+            createdAt: '2001-01-01T00:00:00Z',
+            updatedAt: '2001-02-01T00:00:00Z',
+          },
+        }));
+      });
+
+      afterEach(() => {
+        subject.__ResetDependency__('GitHub');
+      });
+    });
+
     context('not an adminstrator', () => {
       let authStub;
       let checkAuthStub;

--- a/test/user/put.test.js
+++ b/test/user/put.test.js
@@ -13,6 +13,7 @@ describe('PUT /registry/-/user/{id}', () => {
       githubClientId: 'foo-client-id',
       githubSecret: 'bar-secret',
       githubUrl: 'https://example.com',
+      restrictedOrgs: 'foo-org',
     };
 
     process.env = env;

--- a/test/user/put.test.js
+++ b/test/user/put.test.js
@@ -65,7 +65,7 @@ describe('PUT /registry/-/user/{id}', () => {
         await subject(event, stub(), callback);
 
         assert(getCreateAuthStub.calledWithExactly({
-          scopes: ['user:email'],
+          scopes: ['user:email', 'read:org'],
           client_id: 'foo-client-id',
           client_secret: 'bar-secret',
           note: 'codebox private npm registry',
@@ -124,7 +124,7 @@ describe('PUT /registry/-/user/{id}', () => {
         await subject(event, stub(), callback);
 
         assert(getCreateAuthStub.calledWithExactly({
-          scopes: ['user:email'],
+          scopes: ['user:email', 'read:org'],
           client_id: 'foo-client-id',
           client_secret: 'bar-secret',
           note: 'codebox private npm registry',
@@ -213,7 +213,7 @@ describe('PUT /registry/-/user/{id}', () => {
         await subject(event, stub(), callback);
 
         assert(createAuthStub.calledWithExactly({
-          scopes: ['user:email'],
+          scopes: ['user:email', 'read:org'],
           client_id: 'foo-client-id',
           client_secret: 'bar-secret',
           note: 'codebox private npm registry',
@@ -227,7 +227,7 @@ describe('PUT /registry/-/user/{id}', () => {
         await subject(event, stub(), callback);
 
         assert(getCreateAuthStub.calledWithExactly({
-          scopes: ['user:email'],
+          scopes: ['user:email', 'read:org'],
           client_id: 'foo-client-id',
           client_secret: 'bar-secret',
           note: 'codebox private npm registry',


### PR DESCRIPTION
## What did you implement:

Closes #36 

Allow new environment variable  `CODEBOX_RESTRICTED_ORGS` you can set with comma separated list of organization names that are only allowed access. e.g. `org1,org2`.

This allows organisations on public GitHub the ability to grant access to their GitHub application and ensure only those part of the restricted organizations list can then get access to your registry.

Without setting this environment variable anyone with a GitHub / GitHub Enterprise account can have read access to your npm registry by default.  We want to allow read access by default as in the enterprise we want to foster productivity and not hamper access in order for `npm installs` to work. 

## How did you implement it:

* Widened scope to include ability to read user organisations
* If `CODEBOX_RESTRICTED_ORGS` variable is set then check access against github to see if the user belongs to that org if so they get access.
* Admins are still explicitly set using `CODEBOX_ADMINS` variable as organization roles in GitHub are either `member` or `admin` which is way too wide to cater for gradual roll out of publishers.  Not all team members will be admins of an organization that should have publish rights.

## How can we verify it:

* Deploy this branch with relevant env vars / situations set with public github
* Deploy this branch with relevant env vars / situations set with enterprise github
* Check `npm info` operation and `npm publish`

## Todos:
- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
