### PR TITLE
Codebox Tools: Domain Migration / Enforce HTTPS

### DIFF
--- a/.serverless_plugins/codebox-tools/index.js
+++ b/.serverless_plugins/codebox-tools/index.js
@@ -1,0 +1,114 @@
+class CodeboxTools {
+  constructor(serverless, options) {
+    this.options = options;
+    this.serverless = serverless;
+    this.provider = this.serverless.getProvider('aws');
+    this.s3 = new this.provider.sdk.S3({
+      signatureVersion: 'v4',
+    });
+
+    this.bucket = this.serverless.service.resources
+      .Resources
+      .PackageStorage
+      .Properties
+      .BucketName;
+
+    this.commands = {
+      codebox: {
+        usage: 'Useful tools provided by Codebox',
+        commands: {
+          domain: {
+            usage: 'Update packages and migrate to a new domain.',
+            lifecycleEvents: [
+              'migrate',
+            ],
+            options: {
+              host: {
+                usage: 'New host only e.g. example.com',
+                shortcut: 'h',
+                required: true,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    this.hooks = {
+      'codebox:domain:migrate': () => this.migrate(),
+    };
+  }
+
+  migrate(token) {
+    return this.s3.listObjectsV2({
+      Bucket: this.bucket,
+      ContinuationToken: token,
+    })
+    .promise()
+    .then((data) => {
+      const objectPromises = [];
+
+      data.Contents.forEach((item) => {
+        if (item.Key.indexOf('index.json') > -1) {
+          objectPromises.push(
+            new Promise((resolve, reject) => {
+              this.s3.getObject({
+                Bucket: this.bucket,
+                Key: item.Key,
+              }).promise().then((obj) => {
+                resolve({
+                  key: item.Key,
+                  json: JSON.parse(obj.Body.toString()),
+                });
+              }).catch(reject);
+            }));
+        }
+      });
+
+      if (data.IsTruncated) {
+        return this.migrate(data.NextContinuationToken);
+      }
+
+      return Promise.all(objectPromises);
+    }).then((items) => {
+      const putPromises = [];
+
+      items.forEach((item) => {
+        const newItem = Object.assign({}, item);
+
+        Object.keys(item.json.versions).forEach((name) => {
+          const version = item.json.versions[name];
+
+          if (version.dist && version.dist.tarball) {
+            const currentHost = version.dist.tarball.split('/')[2];
+            const currentProtocol = version.dist.tarball.split('/')[0];
+
+            version.dist.tarball = version.dist.tarball
+              .replace(currentHost, this.options.host)
+              .replace(currentProtocol, 'https:');
+
+            newItem.json.versions[name] = version;
+          }
+        });
+
+        putPromises.push(
+          this.s3.putObject({
+            Bucket: this.bucket,
+            Key: newItem.key,
+            Body: JSON.stringify(newItem.json),
+          }).promise());
+      });
+
+      return Promise.all(putPromises);
+    })
+    .then(() => {
+      this.serverless.cli.log(`Domain updated for ${this.options.host}`);
+    })
+    .catch((err) => {
+      this.serverless.cli.log(`Domain update failed for ${this.options.host}`);
+      this.serverless.cli.log(err.message);
+    });
+  }
+}
+
+module.exports = CodeboxTools;

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ echo "$NPM_REGISTRY_LOGIN_URL:_authToken=$NPM_AUTH_TOKEN" >> .npmrc
 **Note:**
 You can then reuse this build step for all of your repositories using your private npm registry.
 
+## Custom Domain
+If you are happy with Codebox on the AWS domain you can setup a custom domain, instructions can be found on the AWS website [here](http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html).
+
+Once you have your custom domain setup you will need to ensure packages already published are migrated by running the following command (supply only the host of your custom domain):
+
+`serverless codebox domain --stage yourstage --host custom-domain.com`
+
 ## Logging
 Upon deploying codebox will create a new SNS Topic specifically for logging.  The console will log the SNS topic ARN you can use to create your own loggers using [Serverless](https://serverless.com/). Deploy your log functions into the same account and you can log with whatever tool you wish.  We hope to use this to drive a live web interface plotting npm usage within your company.
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,6 +6,7 @@ plugins:
   - serverless-webpack
   - log-topic
   - content-handling
+  - codebox-tools
 
 service: codebox-npm
 

--- a/test/serverless_plugins/codebox-tools/index.test.js
+++ b/test/serverless_plugins/codebox-tools/index.test.js
@@ -1,0 +1,159 @@
+/* eslint-disable no-underscore-dangle */
+import AWS from 'aws-sdk'; // eslint-disable-line import/no-extraneous-dependencies
+import CodeboxTools from '../../../.serverless_plugins/codebox-tools';
+
+describe('Plugin: CodeboxTools', () => {
+  const createServerlessStub = (S3, log) => ({
+    getProvider: () => ({
+      sdk: {
+        S3,
+      },
+    }),
+    cli: {
+      log,
+    },
+    service: {
+      resources: {
+        Resources: {
+          PackageStorage: {
+            Properties: {
+              BucketName: 'foo-bucket',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  describe('#migrate()', () => {
+    context('has no keys', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let listObjectsStub;
+
+      beforeEach(() => {
+        serverlessLogStub = stub();
+        serverlessStub = createServerlessStub(
+          spy(() => {
+            listObjectsStub = stub().returns({
+              promise: () => Promise.resolve({
+                IsTruncated: false,
+                Contents: [],
+              }),
+            });
+
+            const awsS3Instance = createStubInstance(AWS.S3);
+            awsS3Instance.listObjectsV2 = listObjectsStub;
+
+            return awsS3Instance;
+          }), serverlessLogStub);
+
+        subject = new CodeboxTools(serverlessStub, { host: 'bar' });
+      });
+
+      it('should request keys correctly', async () => {
+        await subject.migrate();
+
+        assert(listObjectsStub.calledWithExactly({
+          Bucket: 'foo-bucket',
+          ContinuationToken: undefined,
+        }));
+      });
+    });
+
+    context('has keys', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let putObjectStub;
+      let listObjectsStub;
+      let getObjectStub;
+
+      beforeEach(() => {
+        serverlessLogStub = stub();
+        serverlessStub = createServerlessStub(
+          spy(() => {
+            putObjectStub = stub().returns({
+              promise: () => Promise.resolve(),
+            });
+
+            listObjectsStub = stub().returns({
+              promise: () => Promise.resolve({
+                IsTruncated: false,
+                Contents: [{
+                  Key: 'foo/index.json',
+                }],
+              }),
+            });
+
+            getObjectStub = stub().returns({
+              promise: () => Promise.resolve({
+                Body: new Buffer('{"versions":{"1.0.0":{"name":"foo", "dist":{"tarball":"http://old-host/registry/foo/-/bar-1.0.0.tgz"}}}}'),
+              }),
+            });
+
+            const awsS3Instance = createStubInstance(AWS.S3);
+            awsS3Instance.listObjectsV2 = listObjectsStub;
+            awsS3Instance.putObject = putObjectStub;
+            awsS3Instance.getObject = getObjectStub;
+
+            return awsS3Instance;
+          }), serverlessLogStub);
+
+        subject = new CodeboxTools(serverlessStub, { host: 'example.com' });
+      });
+
+      it('should store updated packages correctly', async () => {
+        await subject.migrate();
+
+        assert(putObjectStub.calledWithExactly({
+          Bucket: 'foo-bucket',
+          Key: 'foo/index.json',
+          Body: '{"versions":{"1.0.0":{"name":"foo","dist":{"tarball":"https://example.com/registry/foo/-/bar-1.0.0.tgz"}}}}',
+        }));
+      });
+
+      it('should request keys correctly', async () => {
+        await subject.migrate();
+
+        assert(listObjectsStub.calledWithExactly({
+          Bucket: 'foo-bucket',
+          ContinuationToken: undefined,
+        }));
+      });
+    });
+
+    context('error', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let listObjectsStub;
+
+      beforeEach(() => {
+        serverlessLogStub = stub();
+        serverlessStub = createServerlessStub(
+          spy(() => {
+            listObjectsStub = stub().returns({
+              promise: () => Promise.reject(new Error('Domain Migration Error')),
+            });
+
+            const awsS3Instance = createStubInstance(AWS.S3);
+            awsS3Instance.listObjectsV2 = listObjectsStub;
+
+            return awsS3Instance;
+          }), serverlessLogStub);
+
+        subject = new CodeboxTools(serverlessStub, { host: 'example.com' });
+      });
+
+      it('should log error correctly', async () => {
+        try {
+          await subject.migrate();
+        } catch (err) {
+          assert(serverlessLogStub.calledWithExactly('Domain update failed for example.com'));
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What did you implement:

Helps with #30 

Add codebox plugin to allow the start of adding in new tools.

## How did you implement it:

* Put together a tool to allow migration of domains for packages already published.  It will also enforce that these urls are https.
* Also means anyone who adds a custom domain to API gateway can then update previously published packages.

## How can we verify it:

* Deploy serverless with a stage `e.g. --stage test`
* Publish a package
* Run `sls codebox domain --stage test --host custom.domain.com`
* All `package.json` tarball urls will be updated

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
