### PR TITLE
Fix AWS Profile Support

### DIFF
--- a/.serverless_plugins/log-topic/index.js
+++ b/.serverless_plugins/log-topic/index.js
@@ -1,9 +1,25 @@
 class LogTopic {
-  constructor(serverless) {
+  constructor(serverless, options) {
     this.serverless = serverless;
+    this.provider = this.serverless.getProvider('aws');
+
+    const profile = this.serverless
+    .config
+    .serverless
+    .service
+    .provider
+    .profile;
+
+    if (profile) {
+      const credentials = new this.provider.sdk.SharedIniFileCredentials({
+        profile,
+      });
+
+      this.provider.sdk.config.credentials = credentials;
+    }
 
     this.topicName = `${this.serverless.service.service}-${this.serverless.processedInput.options.stage}-log`;
-    this.provider = this.serverless.getProvider('aws');
+
     this.sns = new this.provider.sdk.SNS({
       signatureVersion: 'v4',
       region: process.env.CODEBOX_REGION,

--- a/.serverless_plugins/remove-storage/index.js
+++ b/.serverless_plugins/remove-storage/index.js
@@ -2,9 +2,26 @@ class RemoveStorageBucket {
   constructor(serverless) {
     this.serverless = serverless;
     this.provider = this.serverless.getProvider('aws');
+
+    const profile = this.serverless
+    .config
+    .serverless
+    .service
+    .provider
+    .profile;
+
+    if (profile) {
+      const credentials = new this.provider.sdk.SharedIniFileCredentials({
+        profile,
+      });
+
+      this.provider.sdk.config.credentials = credentials;
+    }
+
     this.s3 = new this.provider.sdk.S3({
       signatureVersion: 'v4',
     });
+
     this.bucket = this.serverless.service.resources
       .Resources
       .PackageStorage


### PR DESCRIPTION
## What did you implement:

Closes #53 

Fix to ensure there is still support to allow the use of AWS profiles within `serverless.yml` provider section.

## How did you implement it:

* Grabbed profile if one set and used the SDK to set the credentials to use it.

## How can we verify it:

* Edit your `~/.aws/credentials` file to have no default but a named profile
* Set your profile in the `provider` section of the `serverless.yml` file
* Deploy and remove codebox as normal

## Todos:

<!--
Strikethrough the item if not applicable, e.g. `~~
item ~~`
-->

- [x] Write tests
- [x] ~~Write documentation~~
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
