### PR TITLE
Codebox Insights: Basic Indexer

### DIFF
--- a/.serverless_plugins/codebox-tools/index.js
+++ b/.serverless_plugins/codebox-tools/index.js
@@ -1,3 +1,5 @@
+const fetch = require('node-fetch');
+
 class CodeboxTools {
   constructor(serverless, options) {
     this.options = options;
@@ -30,16 +32,35 @@ class CodeboxTools {
               },
             },
           },
+          index: {
+            usage: 'Re-indexes all packages into Codebox Insights, license required.',
+            lifecycleEvents: [
+              'index',
+            ],
+            options: {
+              clientId: {
+                usage: 'Client id for your account.',
+                shortcut: 'c',
+                required: true,
+              },
+              secret: {
+                usage: 'Secret for your account.',
+                shortcut: 's',
+                required: true,
+              },
+            },
+          },
         },
       },
     };
 
     this.hooks = {
       'codebox:domain:migrate': () => this.migrate(),
+      'codebox:index:index': () => this.index(),
     };
   }
 
-  migrate(token) {
+  _getObjects(token) {
     return this.s3.listObjectsV2({
       Bucket: this.bucket,
       ContinuationToken: token,
@@ -66,11 +87,81 @@ class CodeboxTools {
       });
 
       if (data.IsTruncated) {
-        return this.migrate(data.NextContinuationToken);
+        return this._getObjectPromises(data.NextContinuationToken);
       }
 
       return Promise.all(objectPromises);
-    }).then((items) => {
+    });
+  }
+
+  index() {
+    return this._getObjects()
+    .then((items) => {
+      const fetchPromises = [];
+
+      items.forEach((item) => {
+        const version = item.json.versions[
+          item.json['dist-tags'].latest
+        ];
+
+        const logBody = {
+          name: version.name,
+          description: version.description,
+          version: version.version,
+          keywords: version.keywords,
+          license: version.license,
+          contributors: version.contributors,
+          dependencies: version.dependencies,
+          homepage: version.homepage,
+          repository: version.repository,
+          'dist-tags': item.json['dist-tags'],
+        };
+
+        const reqBody = JSON.stringify({
+          timestamp: new Date(),
+          namespace: 'info:package:put',
+          level: 'info',
+          user: {
+            name: "Codebox",
+            avatar: "https://s3-eu-west-1.amazonaws.com/codebox-assets/logo.png",
+          },
+          credentials: {
+            clientId: this.options.clientId,
+            secret: this.options.secret,
+          },
+          body: logBody,
+        });
+
+        fetchPromises.push(fetch('https://log.codebox.sh/v1/send', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: reqBody,
+        }));
+      });
+
+      return Promise.all(fetchPromises);
+    })
+    .then((results) => {
+      const failed = results.filter(r => r.status !== 200);
+
+      if (failed.length > 0) {
+        this.serverless.cli.log(`Codebox indexing had ${failed.length} failures`);
+      }
+    })
+    .then(() => {
+      this.serverless.cli.log('Codebox Insights indexing tool completed');
+    })
+    .catch((err) => {
+      this.serverless.cli.log(`Codebox Insights indexing of data failed for ${this.options.clientId}`);
+      this.serverless.cli.log(err.message);
+    });
+  }
+
+  migrate() {
+    return this._getObjects()
+    .then((items) => {
       const putPromises = [];
 
       items.forEach((item) => {

--- a/test/serverless_plugins/codebox-tools/index.test.js
+++ b/test/serverless_plugins/codebox-tools/index.test.js
@@ -24,6 +24,103 @@ describe('Plugin: CodeboxTools', () => {
       },
     },
   });
+  describe('#index()', () => {
+    context('has no keys', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let listObjectsStub;
+
+      beforeEach(() => {
+        serverlessLogStub = stub();
+        serverlessStub = createServerlessStub(
+          spy(() => {
+            listObjectsStub = stub().returns({
+              promise: () => Promise.resolve({
+                IsTruncated: false,
+                Contents: [],
+              }),
+            });
+
+            const awsS3Instance = createStubInstance(AWS.S3);
+            awsS3Instance.listObjectsV2 = listObjectsStub;
+
+            return awsS3Instance;
+          }), serverlessLogStub);
+
+        subject = new CodeboxTools(serverlessStub, { host: 'bar' });
+      });
+
+      it('should request keys correctly', async () => {
+        await subject.index();
+
+        assert(listObjectsStub.calledWithExactly({
+          Bucket: 'foo-bucket',
+          ContinuationToken: undefined,
+        }));
+      });
+    });
+
+    context('has keys', () => {
+      let subject;
+      let serverlessStub;
+      let serverlessLogStub;
+      let listObjectsStub;
+      let getObjectStub;
+      let fetchStub;
+      let clock;
+
+      beforeEach(() => {
+        clock = useFakeTimers();
+        fetchStub = stub();
+        serverlessLogStub = stub();
+        serverlessStub = createServerlessStub(
+          spy(() => {
+            listObjectsStub = stub().returns({
+              promise: () => Promise.resolve({
+                IsTruncated: false,
+                Contents: [{
+                  Key: 'foo/index.json',
+                }],
+              }),
+            });
+
+            getObjectStub = stub().returns({
+              promise: () => Promise.resolve({
+                Body: new Buffer('{"dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"name":"foo", "dist":{"tarball":"http://old-host/registry/foo/-/bar-1.0.0.tgz"}}}}'),
+              }),
+            });
+
+            const awsS3Instance = createStubInstance(AWS.S3);
+            awsS3Instance.listObjectsV2 = listObjectsStub;
+            awsS3Instance.getObject = getObjectStub;
+
+            return awsS3Instance;
+          }), serverlessLogStub);
+
+        subject = new CodeboxTools(serverlessStub, { host: 'example.com' });
+
+        CodeboxTools.__Rewire__('fetch', fetchStub);
+      });
+
+      it('should call index endpoint correctly', async () => {
+        await subject.index();
+
+        assert(fetchStub.calledWithExactly('https://log.codebox.sh/v1/send', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: '{"timestamp":"1970-01-01T00:00:00.000Z","namespace":"info:package:put","level":"info","user":{"name":"Codebox","avatar":"https://s3-eu-west-1.amazonaws.com/codebox-assets/logo.png"},"credentials":{},"body":{"name":"foo","dist-tags":{"latest":"1.0.0"}}}',
+        }));
+      });
+
+      afterEach(() => {
+        clock.restore();
+        CodeboxTools.__ResetDependency__('fetch');
+      });
+    });
+  });
 
   describe('#migrate()', () => {
     context('has no keys', () => {


### PR DESCRIPTION
## What did you implement:

Rough and ready indexer tool for data to allow current users that have the registry already deployed to onboard with Insights if they wish to.

## How did you implement it:

* Added new codebox tool to allow the following command:
`sls codebox index -c CLIENT_ID -secret SECRET_HERE --stage your_registry_stage`

## How can we verify it:

* Have an account created on the Insights platform, run relevant command for your deployed registry as above.  Login to your insights instance and see all the package data and analysis 🎇.

## Todos:

- [x] Write tests
- [x] ~~Write documentation~~ Coming soon!
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
