### PR TITLE
Serverless Version: 1.9.0

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-frameworkVersion: '=1.8.0'
+frameworkVersion: '=1.9.0'
 
 plugins:
   - environment-variables


### PR DESCRIPTION
## What did you implement:

Updated constraint to to keep on top of latest release of Serverless @ 1.9.0

## How did you implement it:

Bumped version in `serverless.yml` and ran tests plus manual deployment / testing.

## How can we verify it:

* Install latest version of serverless and deploy registry

## Todos:

- [x] ~~Write tests~~
- [x] ~~Write documentation~~
- [x] ~~Fix linting errors~~
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** YES
