### PR TITLE
Implement Authorization Header

### DIFF
--- a/src/adapters/logger.js
+++ b/src/adapters/logger.js
@@ -12,6 +12,7 @@ export default class Logger {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.credentials.clientId}:${this.credentials.secret}`,
         },
         body: JSON.stringify(json),
       });
@@ -21,7 +22,6 @@ export default class Logger {
   async error(user, { stack, message }) {
     const json = {
       user,
-      credentials: this.credentials,
       timestamp: new Date(),
       level: 'error',
       namespace: `error:${this.namespace}`,
@@ -37,7 +37,6 @@ export default class Logger {
   async info(user, message) {
     const json = {
       user,
-      credentials: this.credentials,
       timestamp: new Date(),
       level: 'info',
       namespace: `info:${this.namespace}`,

--- a/test/adapters/logger.test.js
+++ b/test/adapters/logger.test.js
@@ -32,8 +32,9 @@ describe('Logger', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          Authorization: 'Bearer foo-client-id:bar-secret',
         },
-        body: '{"user":{"name":"foo","avatar":"https://example.com"},"credentials":{"clientId":"foo-client-id","secret":"bar-secret"},"timestamp":"1970-01-01T00:00:00.000Z","level":"info","namespace":"info:foo:bar","body":{"foo":"bar"}}',
+        body: '{"user":{"name":"foo","avatar":"https://example.com"},"timestamp":"1970-01-01T00:00:00.000Z","level":"info","namespace":"info:foo:bar","body":{"foo":"bar"}}',
       }));
     });
   });
@@ -54,8 +55,9 @@ describe('Logger', () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          Authorization: 'Bearer foo-client-id:bar-secret',
         },
-        body: '{"user":{"name":"foo","avatar":"https://example.com"},"credentials":{"clientId":"foo-client-id","secret":"bar-secret"},"timestamp":"1970-01-01T00:00:00.000Z","level":"error","namespace":"error:foo:bar","body":{"message":"Foo Bar","stack":"foo bar stack"}}',
+        body: '{"user":{"name":"foo","avatar":"https://example.com"},"timestamp":"1970-01-01T00:00:00.000Z","level":"error","namespace":"error:foo:bar","body":{"message":"Foo Bar","stack":"foo bar stack"}}',
       }));
     });
   });


### PR DESCRIPTION
## What did you implement:

Update to use Authorization header when authenticating for insights data.  Much better and tidy implementation.

## How did you implement it:

Send authorization header as a bearer token.

## How can we verify it:

Deploy registry with insights account ensure integrations and data is indexed.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
