### PR TITLE
CLI: Logout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -94,6 +94,14 @@ functions:
           path: 'registry/-/user/{id}'
           method: put
 
+  userDelete:
+    handler: userDelete.default
+    events:
+      - http:
+          path: 'registry/-/user/token/{token}'
+          method: delete
+          authorizer: authorizerGithub
+
   tarGet:
     handler: tarGet.default
     events:

--- a/src/user/delete.js
+++ b/src/user/delete.js
@@ -1,0 +1,43 @@
+import url from 'url';
+import GitHub from 'github';
+
+export default async ({ pathParameters }, context, callback) => {
+  const {
+    token,
+  } = pathParameters;
+
+  const parsedUrl = url.parse(process.env.githubUrl);
+  const github = new GitHub({
+    host: parsedUrl.host,
+    protocol: 'https',
+    pathPrefix: parsedUrl.path,
+  });
+
+  github.authenticate({
+    type: 'basic',
+    username: process.env.githubClientId,
+    password: process.env.githubSecret,
+  });
+
+  try {
+    await github.authorization.reset({
+      client_id: process.env.githubClientId,
+      access_token: token,
+    });
+
+    return callback(null, {
+      statusCode: 200,
+      body: JSON.stringify({
+        ok: true,
+      }),
+    });
+  } catch (err) {
+    return callback(null, {
+      statusCode: 500,
+      body: JSON.stringify({
+        ok: false,
+        error: err.message,
+      }),
+    });
+  }
+};

--- a/test/user/delete.test.js
+++ b/test/user/delete.test.js
@@ -1,0 +1,140 @@
+/* eslint-disable no-underscore-dangle */
+import GitHub from 'github';
+import subject from '../../src/user/delete';
+
+describe('DELETE /registry/-/user/token/{token}', () => {
+  let event;
+  let callback;
+  let gitHubSpy;
+  let gitHubInstance;
+
+  beforeEach(() => {
+    const env = {
+      githubClientId: 'foo-client-id',
+      githubSecret: 'bar-secret',
+      githubUrl: 'https://example.com',
+      restrictedOrgs: 'foo-org',
+    };
+
+    process.env = env;
+
+    callback = stub();
+  });
+
+  describe('logout', () => {
+    context('with valid token', () => {
+      let authStub;
+      let resetAuthStub;
+
+      beforeEach(() => {
+        event = {
+          pathParameters: {
+            token: 'foo-token',
+          },
+        };
+
+        gitHubSpy = spy(() => {
+          gitHubInstance = createStubInstance(GitHub);
+          authStub = stub();
+          resetAuthStub = stub();
+
+          gitHubInstance.authenticate = authStub;
+          gitHubInstance.authorization = {
+            reset: resetAuthStub,
+          };
+
+          return gitHubInstance;
+        });
+
+        subject.__Rewire__({
+          GitHub: gitHubSpy,
+        });
+      });
+
+      it('should authenticate using app credentials with github', async () => {
+        await subject(event, stub(), callback);
+
+        assert(authStub.calledWithExactly({
+          type: 'basic',
+          username: 'foo-client-id',
+          password: 'bar-secret',
+        }));
+      });
+
+      it('should reset token with github', async () => {
+        await subject(event, stub(), callback);
+
+        assert(resetAuthStub.calledWithExactly({
+          client_id: 'foo-client-id',
+          access_token: 'foo-token',
+        }));
+      });
+
+      it('should return 200 response', async () => {
+        await subject(event, stub(), callback);
+
+        assert(callback.calledWithExactly(null, {
+          statusCode: 200,
+          body: '{"ok":true}',
+        }));
+      });
+
+      afterEach(() => {
+        subject.__ResetDependency__('GitHub');
+      });
+    });
+
+    context('with invalid token', () => {
+      let authStub;
+      let resetAuthStub;
+
+      beforeEach(() => {
+        event = {
+          pathParameters: {
+            token: 'foo-bad-token',
+          },
+        };
+
+        gitHubSpy = spy(() => {
+          gitHubInstance = createStubInstance(GitHub);
+          authStub = stub();
+          resetAuthStub = stub().throws(new Error('Invalid token'));
+
+          gitHubInstance.authenticate = authStub;
+          gitHubInstance.authorization = {
+            reset: resetAuthStub,
+          };
+
+          return gitHubInstance;
+        });
+
+        subject.__Rewire__({
+          GitHub: gitHubSpy,
+        });
+      });
+
+      it('should authenticate using app credentials with github', async () => {
+        await subject(event, stub(), callback);
+
+        assert(authStub.calledWithExactly({
+          type: 'basic',
+          username: 'foo-client-id',
+          password: 'bar-secret',
+        }));
+      });
+
+      it('should return a 500 error', async () => {
+        await subject(event, stub(), callback);
+
+        assert(callback.calledWithExactly(null, {
+          statusCode: 500,
+          body: '{"ok":false,"error":"Invalid token"}',
+        }));
+      });
+
+      afterEach(() => {
+        subject.__ResetDependency__('GitHub');
+      });
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     distTagsPut: ['./bootstrap', './src/dist-tags/put.js'],
     distTagsDelete: ['./bootstrap', './src/dist-tags/delete.js'],
     userPut: ['./bootstrap', './src/user/put.js'],
+    userDelete: ['./bootstrap', './src/user/delete.js'],
     tarGet: ['./bootstrap', './src/tar/get.js'],
   },
   output: {


### PR DESCRIPTION
## What did you implement:

Add logout cli support as per #71 @ganapativs 

## How did you implement it:

Takes the passed token then uses GitHub to reset it.  One thing to note is that there is about a 4-5 sec cache before the custom authoriser then says it is invalid after testing.

## How can we verify it:

* Get branch and deploy it
* Use `npm logout`
* Attempt `npm publish`

## Todos:
- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
