### PR TITLE
Fix: Tarball Domain

### DIFF
--- a/.serverless_plugins/set-api-host/index.js
+++ b/.serverless_plugins/set-api-host/index.js
@@ -1,0 +1,70 @@
+class SetAPIHost {
+  constructor(serverless, options) {
+    this.options = options;
+    this.serverless = serverless;
+    this.provider = this.serverless.getProvider('aws');
+
+    this.awsInfo = this.serverless
+      .pluginManager
+      .plugins
+      .find(p => p.constructor.name === 'AwsInfo');
+
+    this.registry = this.serverless
+    .service
+    .provider
+    .environment
+    .registry;
+
+    this.hooks = {
+      'after:deploy:deploy': this.afterDeploy.bind(this),
+    };
+  }
+
+  afterDeploy() {
+    const lambda = new this.provider.sdk.Lambda({
+      signatureVersion: 'v4',
+      region: this.options.region,
+    });
+
+    const publishFunction = this
+    .awsInfo
+    .gatheredData
+    .info
+    .functions
+    .find(f => f.name === 'put');
+
+    const params = {
+      FunctionName: publishFunction.deployedName,
+    };
+
+    lambda
+    .getFunctionConfiguration(params)
+    .promise()
+    .then((config) => {
+      const env = config.Environment;
+
+      if (env.Variables.apiEndpoint) {
+        // Already set / not a first time deployment.
+        return;
+      }
+
+      env.Variables = Object.assign({}, env.Variables, {
+        apiEndpoint: `${this.awsInfo.gatheredData.info.endpoint}/registry`,
+      });
+
+      const updatedConfig = {
+        FunctionName: publishFunction.deployedName,
+        Environment: env,
+      };
+
+      return lambda
+      .updateFunctionConfiguration(updatedConfig)
+      .promise();
+    })
+    .catch((err) => {
+      this.serverless.cli.log(err.message);
+    });
+  }
+}
+
+module.exports = SetAPIHost;

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,6 +6,7 @@ plugins:
   - serverless-webpack
   - content-handling
   - codebox-tools
+  - set-api-host
 
 service: codebox-npm
 

--- a/src/contextFactory.js
+++ b/src/contextFactory.js
@@ -56,6 +56,7 @@ export default (namespace, { headers, requestContext }) => {
     bucket,
     region,
     logTopic,
+    apiEndpoint,
   } = process.env;
 
   const cmd = command(headers);
@@ -63,6 +64,7 @@ export default (namespace, { headers, requestContext }) => {
   return {
     command: cmd,
     registry,
+    apiEndpoint,
     user: user(requestContext.authorizer),
     storage: storage(region, bucket),
     log: log(cmd, namespace, region, logTopic),

--- a/src/put/publish.js
+++ b/src/put/publish.js
@@ -4,6 +4,7 @@ export default async ({
   body,
 }, {
   registry,
+  apiEndpoint,
   user,
   storage,
   npm,
@@ -46,9 +47,7 @@ export default async ({
   const versionData = pkg.versions[version];
 
   const tarballFilename = encodeURIComponent(versionData.dist.tarball.split('/-/')[1]);
-  const tarballBaseUrl = versionData.dist.tarball.split('/registry/')[0];
-  const baseUrlParts = tarballBaseUrl.split(':');
-  versionData.dist.tarball = `https:${baseUrlParts[1]}/registry/${pathParameters.name}/-/${tarballFilename}`;
+  versionData.dist.tarball = `${apiEndpoint}/${pathParameters.name}/-/${tarballFilename}`;
 
   let json = {};
 

--- a/test/fixtures/package.js
+++ b/test/fixtures/package.js
@@ -16,7 +16,7 @@ export default {
           version: `${major}.${minor}.${patch}`,
           deprecated: msg,
           dist: {
-            tarball: `https://example.com/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
+            tarball: `https://example.com/prod/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
           },
         },
       },
@@ -43,7 +43,7 @@ export default {
           name: 'foo-bar-package',
           version: `${major}.${minor}.${patch}`,
           dist: {
-            tarball: `https://example.com/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
+            tarball: `https://example.com/prod/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
           },
         },
       },
@@ -70,7 +70,7 @@ export default {
           name: 'foo-bar-package',
           version: `${major}.${minor}.${patch}`,
           dist: {
-            tarball: `https://example.com/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
+            tarball: `https://example.com/prod/registry/foo-bar-package/-/foo-bar-package-${major}.${minor}.${patch}.tgz`,
           },
         },
       },

--- a/test/put/publish.test.js
+++ b/test/put/publish.test.js
@@ -52,6 +52,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               info: stub(),
@@ -76,6 +77,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               error: stub(),
@@ -101,6 +103,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               info: stub(),
@@ -130,6 +133,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               info: stub(),
@@ -168,6 +172,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               info: stub(),
@@ -192,6 +197,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               error: stub(),
@@ -218,6 +224,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               error: stub(),
@@ -255,6 +262,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               error: stub(),
@@ -298,6 +306,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               error: stub(),
@@ -335,6 +344,7 @@ describe('PUT /registry/{name}', () => {
             patch: 0,
           }), {
             registry: 'https://example.com',
+            apiEndpoint: 'https://example.com/prod/registry',
             user: stub(),
             log: {
               error: stub(),


### PR DESCRIPTION
## What did you implement:

Uses explicit url when setting tarball url on publish as can't rely on yarn and npm both working in the same way at the moment.

## How did you implement it:

* Use an env var against the publish function so it can be used.

## How can we verify it:

* Deploy registry, publish and install that package with a clean cache
* `npm t`

## Todos:
- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
