### PR TITLE
Fix --tag support for npm publish

### DIFF
--- a/src/put/publish.js
+++ b/src/put/publish.js
@@ -67,7 +67,6 @@ export default async ({
     }
 
     json['dist-tags'][tag] = version;
-    json['dist-tags'].latest = version;
     json._attachments[`${name}-${version}.tgz`] = pkg._attachments[`${name}-${version}.tgz`]; // eslint-disable-line no-underscore-dangle
     json.versions[version] = versionData;
   } catch (storageError) {


### PR DESCRIPTION
## What did you implement:

Closes #80

Fixes the fact latest is always set on publish this ensure `--tag` is supported correctly.  Found by @mjalkio.

## How did you implement it:

* Remove errornus line in publish function.

## How can we verify it:

* Deploy and test behaviour with integration tests

## Todos:

~~Write tests~~
~~Write documentation~~
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
