### PR TITLE
S3 Package: Server-side Encryption

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -135,6 +135,30 @@ resources:
       Properties:
         AccessControl: Private
         BucketName: ${self:provider.environment.bucket}
+    PackageStoragePolicy:
+      Type: "AWS::S3::BucketPolicy"
+      DependsOn: "PackageStorage"
+      Properties:
+        Bucket:
+          Ref: "PackageStorage"
+        PolicyDocument:
+          Statement:
+            - Sid: DenyIncorrectEncryptionHeader
+              Effect: Deny
+              Principal: "*"
+              Action: "s3:PutObject"
+              Resource: "arn:aws:s3:::${self:provider.environment.bucket}/*"
+              Condition:
+               StringNotEquals:
+                 "s3:x-amz-server-side-encryption": AES256
+            - Sid: DenyUnEncryptedObjectUploads
+              Effect: Deny
+              Principal: "*"
+              Action: "s3:PutObject"
+              Resource: "arn:aws:s3:::${self:provider.environment.bucket}/*"
+              Condition:
+                "Null":
+                 "s3:x-amz-server-side-encryption": true
 
 custom:
   webpackIncludeModules: true

--- a/src/adapters/s3.js
+++ b/src/adapters/s3.js
@@ -15,6 +15,7 @@ export default class Storage {
     return this.S3.putObject({
       Key: key,
       Body: encoding === 'base64' ? new Buffer(data, 'base64') : data,
+      ServerSideEncryption: 'AES256',
     }).promise();
   }
 

--- a/test/adapters/s3.test.js
+++ b/test/adapters/s3.test.js
@@ -37,6 +37,7 @@ describe('S3', () => {
         assert(putObjectStub.calledWithExactly({
           Key: 'foo-key',
           Body: new Buffer('test', 'base64'),
+          ServerSideEncryption: 'AES256',
         }));
       });
     });
@@ -53,6 +54,7 @@ describe('S3', () => {
         assert(putObjectStub.calledWithExactly({
           Key: 'foo-key',
           Body: 'test',
+          ServerSideEncryption: 'AES256',
         }));
       });
     });


### PR DESCRIPTION
## What did you implement:

By default add AES256 encryption for data sitting in S3.  


> **Use Server-Side Encryption with Amazon S3-Managed Keys (SSE-S3)**
Each object is encrypted with a unique key employing strong multi-factor encryption. As an additional safeguard, it encrypts the key itself with a master key that it regularly rotates. Amazon S3 server-side encryption uses one of the strongest block ciphers available, 256-bit Advanced Encryption Standard (AES-256), to encrypt your data.

## How did you implement it:

* Added bucket policy to enforce encrypted data to ensure all objects are published encrypted.

## How can we verify it:

* `npm t`
* Deploy registry and attempt publish and dist-tags operations

## Todos:

- [x] Write tests
~~Write documentation~~
- [x] Fix linting errors
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** YES
