### PR TITLE
Changing Serverless version to greater than

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,4 +1,4 @@
-frameworkVersion: '=1.11.0'
+frameworkVersion: '>=1.11.0'
 
 plugins:
   - environment-variables


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If
something is not applicable leave it empty but
leave it in the PR
2. Please follow the template, otherwise we'll
have to ask you to update it and it will take
longer until your PR is merged
-->

## What did you implement:

Changed the required Serverless version to greater than instead of equals.

I was trying to use codebox with the newest version of serverless (1.13.2) and got the version error. I thought this change would make it easier to maintain codebox going forward. 

<!--
Briefly describe the feature
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly
describe your implementation so its easy for us to
understand and review your code.
-->

## How can we verify it:

View `serverless.yml` or deploy codebox-npm with a new version of serverless.
<!--
Add any applicable config, commands, screenshots
or other resources
to make it easy for us to verify this works. The
easier you make it for us
to review a PR, the faster we can review and merge
it.
-->

## Todos:

<!--
Strikethrough the item if not applicable, e.g. `~~
item ~~`
-->

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
