### PR TITLE
Fix for #84 - Remove old version attachments while publishing.

### DIFF
--- a/src/put/publish.js
+++ b/src/put/publish.js
@@ -66,6 +66,10 @@ export default async ({
     }
 
     json['dist-tags'][tag] = version;
+    // Fix - https://github.com/craftship/codebox-npm/issues/84
+    // Remove old version attachments to prevent index.json size growth
+    // Only keep latest version attachment for future use
+    json._attachments = {}; // eslint-disable-line no-underscore-dangle
     json._attachments[`${name}-${version}.tgz`] = pkg._attachments[`${name}-${version}.tgz`]; // eslint-disable-line no-underscore-dangle
     json.versions[version] = versionData;
   } catch (storageError) {


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If
something is not applicable leave it empty but
leave it in the PR
2. Please follow the template, otherwise we'll
have to ask you to update it and it will take
longer until your PR is merged
-->

## What did you implement:

Fix for https://github.com/craftship/codebox-npm/issues/84

<!--
Briefly describe the feature
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly
describe your implementation so its easy for us to
understand and review your code.
-->
Remove old version attachments to prevent index.json size growth, Only keep latest version attachment for future use.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots
or other resources
to make it easy for us to verify this works. The
easier you make it for us
to review a PR, the faster we can review and merge
it.
-->
Just publish update to a package, you should see size on index.json is reduced.

## Todos:

<!--
Strikethrough the item if not applicable, e.g. `~~
item ~~`
-->

- [x] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Tag `ready for review` or `wip`

***Is this a breaking change?:*** **NO**/YES
