### PR TITLE
CODEBOX_ADMINS github usernames should be case-insensitive

### DIFF
--- a/src/authorizers/github.js
+++ b/src/authorizers/github.js
@@ -112,7 +112,8 @@ export default async ({ methodArn, authorizationToken }, context, callback) => {
     }
 
     if (process.env.admins) {
-      isAdmin = process.env.admins.split(',').indexOf(user.login) > -1;
+      let login = user.login.toLowerCase();
+      isAdmin = process.env.admins.toLowerCase().split(',').indexOf(login) > -1;
     }
 
     const policy = generatePolicy({

--- a/src/authorizers/github.js
+++ b/src/authorizers/github.js
@@ -112,7 +112,7 @@ export default async ({ methodArn, authorizationToken }, context, callback) => {
     }
 
     if (process.env.admins) {
-      let login = user.login.toLowerCase();
+      const login = user.login.toLowerCase();
       isAdmin = process.env.admins.toLowerCase().split(',').indexOf(login) > -1;
     }
 

--- a/test/authorizers/github.test.js
+++ b/test/authorizers/github.test.js
@@ -414,7 +414,7 @@ describe('GitHub Authorizer', () => {
           authStub = stub();
           checkAuthStub = stub().returns({
             user: {
-              login: 'foo-user',
+              login: 'Foo-User',
               avatar_url: 'https://example.com',
             },
             created_at: '2001-01-01T00:00:00Z',
@@ -479,7 +479,7 @@ describe('GitHub Authorizer', () => {
             ],
           },
           context: {
-            username: 'foo-user',
+            username: 'Foo-User',
             avatar: 'https://example.com',
             createdAt: '2001-01-01T00:00:00Z',
             updatedAt: '2001-02-01T00:00:00Z',


### PR DESCRIPTION
One of our admin users give me their github username, but the API returned their user-name with some capitol letters which made them appear as though they were not administrators.

## What did you implement:

Closes #12345 (Github)

Github admin usernames should be case-insensitive.

## How did you implement it:

Lower-case the usernames and then do indexOf() to check if the username exists.

## How can we verify it:

Set CODEBOX_ADMINS to contain your github username in a case that is different than the canonical casing.

...also the unit test verifies it works.

## Todos:

<!--
Strikethrough the item if not applicable, e.g. `~~
item ~~`
-->

- [x ] Write tests
- [ ] ~~Write documentation~~
- [ ] ~~Fix linting errors~~
- [ ] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
