### PR TITLE
Fix Attachment Growth Sizes

### DIFF
--- a/src/put/publish.js
+++ b/src/put/publish.js
@@ -66,7 +66,7 @@ export default async ({
     }
 
     json['dist-tags'][tag] = version;
-    json._attachments = {};
+    json._attachments = {}; // eslint-disable-line no-underscore-dangle
     json._attachments[`${name}-${version}.tgz`] = pkg._attachments[`${name}-${version}.tgz`]; // eslint-disable-line no-underscore-dangle
     json.versions[version] = versionData;
   } catch (storageError) {

--- a/src/put/publish.js
+++ b/src/put/publish.js
@@ -66,6 +66,7 @@ export default async ({
     }
 
     json['dist-tags'][tag] = version;
+    json._attachments = {};
     json._attachments[`${name}-${version}.tgz`] = pkg._attachments[`${name}-${version}.tgz`]; // eslint-disable-line no-underscore-dangle
     json.versions[version] = versionData;
   } catch (storageError) {

--- a/test/put/publish.test.js
+++ b/test/put/publish.test.js
@@ -240,11 +240,10 @@ describe('PUT /registry/{name}', () => {
         const pkg2 = JSON.parse(pkg.withAttachments({ major: 2, minor: 0, patch: 0 }).toString());
 
         const versions = Object.assign(pkg1.versions, pkg2.versions);
-        const attachments = Object.assign(pkg1._attachments, pkg2._attachments);
 
         const updatedPackage = Object.assign({}, pkg1, pkg2);
         updatedPackage.versions = versions;
-        updatedPackage._attachments = attachments;
+        updatedPackage._attachments = pkg2._attachments;
 
         const expected = JSON.stringify(updatedPackage);
 


### PR DESCRIPTION
## What did you implement:

Closes #91 #84

## How did you implement it:

* Keep latest attachment only within publish
* Updated test to reflect the new behaviour

## How can we verify it:
* `npm t`
* Deploy and ensure only latest attachment is kept within the json.

## Todos:
- [x] Write tests
~~Write documentation~~
- [x] Fix linting errors~~
- [x] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO/YES
