### PR TITLE
Change the readme to point at latest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The quickest way to deploy your own npm registry from your local machine is to f
 * Latest version of Serverless installed globally (`npm install serverless -g` or `yarn global add serverless`).
 
 #### Steps
-* `serverless install --url https://github.com/craftship/codebox-npm/tree/0.21.0 --name my-npm-registry` - pick whichever name you prefer for your registry
+* `serverless install --url https://github.com/craftship/codebox-npm --name my-npm-registry` - pick whichever name you prefer for your registry
 * `cd my-npm-registry`
 * `npm install`
 * Setup your environment variables:


### PR DESCRIPTION
<!--
1. Do not remove any section of the template. If
something is not applicable leave it empty but
leave it in the PR
2. Please follow the template, otherwise we'll
have to ask you to update it and it will take
longer until your PR is merged
-->

## What did you implement:

Changed the README.md to point at the latest code instead of pinned to 0.21 tree. Several issues in the issue queue seem to be fixed in the latest version but I think (because I did this) people are installing 0.21 by default.

Only downside would be people would be pulling from master instead of a tag, which might be sub-optimal.

<!--
Briefly describe the feature
-->

## How did you implement it:

Changed the text of the readme!

<!--
If this is a nontrivial change please briefly
describe your implementation so its easy for us to
understand and review your code.
-->

## How can we verify it:

Copy the changed command and makes sure it downloads!

## Todos:

<!--
Strikethrough the item if not applicable, e.g. `~~
item ~~`
-->

- [ ] ~~Write tests~~
- [ x ] Write documentation
- [ ] ~~Fix linting errors~~
- [ ] Tag `ready for review` or `wip`

***Is this a breaking change?:*** NO
